### PR TITLE
#243 Show task description and assumptions on quote

### DIFF
--- a/lib/ui/quoting/generate_quote_pdf.dart
+++ b/lib/ui/quoting/generate_quote_pdf.dart
@@ -244,13 +244,26 @@ Future<File> generateQuotePdf(
               ),
             ]);
 
+            // Group-level description
+            if (Strings.isNotBlank(group.group.description)) {
+              content.add(
+                pw.Padding(
+                  padding: const pw.EdgeInsets.only(left: 8, top: 2),
+                  child: pw.Text(
+                    group.group.description,
+                    style: const pw.TextStyle(fontSize: 12),
+                  ),
+                ),
+              );
+            }
+
             // Group-level assumption
             if (Strings.isNotBlank(group.group.assumption)) {
               content.add(
                 pw.Padding(
                   padding: const pw.EdgeInsets.only(left: 8, top: 2),
                   child: pw.Text(
-                    group.group.assumption,
+                    'Assumptions: ${group.group.assumption}',
                     style: pw.TextStyle(
                       fontStyle: pw.FontStyle.italic,
                       fontSize: 12,


### PR DESCRIPTION
## Summary
- include each task group's description in generated quote PDFs
- label each task group's assumption explicitly as `Assumptions:` in the PDF

Closes #243

## Testing
- Ran via Dart MCP:
  - `test/ui/quoting/quote_details_screen_test.dart`
  - `test/ui/quoting/quote_details_screen_smoke_test.dart`
- Current failures are in existing quote-details test flows and not introduced by this PDF change, so issue is marked implemented (not tested).