### PR TITLE
#238 Show open and completed totals on task dashlet

### DIFF
--- a/lib/ui/nav/dashboards/main/dashlets/todo.dart
+++ b/lib/ui/nav/dashboards/main/dashlets/todo.dart
@@ -26,11 +26,12 @@ class ToDoDashlet extends StatelessWidget {
   @override
   Widget build(BuildContext context) => DashletCard<int>.route(
     label: 'Todo',
-    hint: 'Create actionable items',
+    hint: 'Create actionable items and track open/completed',
     icon: Icons.work,
     value: () async {
-      final todos = await DaoToDo().getFiltered(status: ToDoStatus.open);
-      return DashletValue(todos.length);
+      final open = await DaoToDo().getFiltered(status: ToDoStatus.open);
+      final completed = await DaoToDo().getFiltered(status: ToDoStatus.done);
+      return DashletValue(open.length, '${completed.length} completed');
     },
     route: '/home/todo',
   );


### PR DESCRIPTION
Fixes #238

Changes:
- Update the `Todo` dashlet to show:
  - primary value: open task count
  - secondary value: completed task count
- Update the dashlet hint to clarify open/completed tracking.

Validation:
- `flutter analyze lib/ui/nav/dashboards/main/dashlets/todo.dart`

Note:
- No dedicated automated test currently exists for this dashlet widget/value binding.