### PR TITLE
Preserve inherited task billing when editing tasks

### DIFF
--- a/assets/sql/upgrade_list.json
+++ b/assets/sql/upgrade_list.json
@@ -1,4 +1,5 @@
 [
+  "assets/sql/upgrade_scripts/v147.sql",
   "assets/sql/upgrade_scripts/v145.sql",
   "assets/sql/upgrade_scripts/v144.sql",
   "assets/sql/upgrade_scripts/v143.sql",

--- a/assets/sql/upgrade_scripts/v147.sql
+++ b/assets/sql/upgrade_scripts/v147.sql
@@ -1,0 +1,10 @@
+-- Normalize task billing type to inherited when it matches the parent job.
+-- This fixes tasks that were unintentionally saved with explicit values.
+UPDATE task
+SET billing_type = NULL
+WHERE billing_type IS NOT NULL
+  AND billing_type = (
+    SELECT j.billing_type
+    FROM job j
+    WHERE j.id = task.job_id
+  );

--- a/lib/ui/crud/task/edit_task_screen.dart
+++ b/lib/ui/crud/task/edit_task_screen.dart
@@ -34,11 +34,12 @@ import 'photo_crud.dart';
 class TaskEditScreen extends StatefulWidget {
   final Job job;
   final Task? task;
-
-  late final BillingType billingType;
+  late final BillingType? billingType;
 
   TaskEditScreen({required this.job, super.key, this.task}) {
-    billingType = task?.billingType ?? job.billingType;
+    // Use explicit task override only.
+    // null means "Inherited" from job billing type.
+    billingType = task?.billingType;
   }
 
   @override


### PR DESCRIPTION
Fixes task billing inheritance regression.

Changes:
- keep task billing type nullable in task editor (`null` = inherited)
- add migration `v147.sql` to normalize redundant task billing overrides to inherited

Validation:
- targeted analyze run on touched files