### PR TITLE
Fix fixed-price invoice generation when grouping by date

### DIFF
--- a/lib/dao/dao_invoice_time_and_materials.dart
+++ b/lib/dao/dao_invoice_time_and_materials.dart
@@ -30,11 +30,10 @@ Future<Invoice> createTimeAndMaterialsInvoice(
     throw InvoiceException("Hourly rate must be set for job '${job.summary}'");
   }
 
-  assert(
-    job.billingType == BillingType.timeAndMaterial ||
-        (job.billingType == BillingType.fixedPrice && groupByTask),
-    'FixedPrice must only use group by Task',
-  );
+  // Fixed price invoicing must be grouped by task so fixed-price labour
+  // task items are emitted correctly.
+  final effectiveGroupByTask =
+      job.billingType == BillingType.fixedPrice || groupByTask;
 
   var totalAmount = MoneyEx.zero;
 
@@ -81,7 +80,7 @@ Future<Invoice> createTimeAndMaterialsInvoice(
   }
 
   // Group by task: Create invoice line group for the task
-  if (groupByTask) {
+  if (effectiveGroupByTask) {
     totalAmount += await createInvoiceForTasks(invoiceId, job, selectedTaskIds);
   }
   // Group by date

--- a/lib/ui/invoicing/dialog_select_tasks.dart
+++ b/lib/ui/invoicing/dialog_select_tasks.dart
@@ -131,6 +131,8 @@ class _DialogTaskSelectionState extends DeferredState<DialogTaskSelection> {
 
   @override
   Future<void> asyncInitState() async {
+    _groupByTask = widget.job.billingType == BillingType.fixedPrice;
+
     billBookingFee = canBillBookingFee =
         widget.job.billingType == BillingType.timeAndMaterial &&
         !widget.job.bookingFeeInvoiced;
@@ -187,20 +189,23 @@ class _DialogTaskSelectionState extends DeferredState<DialogTaskSelection> {
             DropdownButton<bool>(
               value: _groupByTask,
               isExpanded: true,
-              onChanged: (value) {
-                setState(() {
-                  _groupByTask = value ?? true;
-                });
-              },
-              items: const [
-                DropdownMenuItem(
+              onChanged: widget.job.billingType == BillingType.fixedPrice
+                  ? null
+                  : (value) {
+                      setState(() {
+                        _groupByTask = value ?? true;
+                      });
+                    },
+              items: [
+                const DropdownMenuItem(
                   value: true,
                   child: Text('Group by Task/Date'),
                 ),
-                DropdownMenuItem(
-                  value: false,
-                  child: Text('Group by Date/Task'),
-                ),
+                if (widget.job.billingType != BillingType.fixedPrice)
+                  const DropdownMenuItem(
+                    value: false,
+                    child: Text('Group by Date/Task'),
+                  ),
               ],
             ),
             if (canBillBookingFee)
@@ -249,7 +254,9 @@ class _DialogTaskSelectionState extends DeferredState<DialogTaskSelection> {
             InvoiceOptions(
               selectedTaskIds: selectedTaskIds,
               billBookingFee: billBookingFee,
-              groupByTask: _groupByTask,
+              groupByTask:
+                  widget.job.billingType == BillingType.fixedPrice ||
+                  _groupByTask,
               contact: _selectedContact,
             ),
           );


### PR DESCRIPTION
Fixes direct invoice generation for fixed-price tasks.

Changes:
- enforce task-grouped invoice generation for fixed-price jobs
- disable invalid grouping option in task selection dialog for fixed-price jobs
- add regression test for fixed-price labour task item invoicing path

Validation:
- targeted analyze and flutter test run for invoice mixed billing tests