### PR TITLE
Route todo notification taps to Todo screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ import 'ui/widgets/desktop_back_gesture.dart';
 import 'ui/widgets/layout/layout.g.dart';
 import 'util/dart/log.dart';
 import 'util/flutter/hmb_theme.dart';
+import 'util/flutter/notifications/local_notifs.dart';
 import 'util/flutter/platform_ex.dart';
 
 //----------------------------------------------------------------------
@@ -85,14 +86,27 @@ class _HmbAppState extends State<HmbApp> with WidgetsBindingObserver {
   @override
   void initState() {
     super.initState();
+    LocalNotifs().onNotificationPayload = _onNotificationPayload;
     WidgetsBinding.instance.addObserver(this);
     unawaited(_syncBookings());
   }
 
   @override
   void dispose() {
+    LocalNotifs().onNotificationPayload = null;
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
+  }
+
+  void _onNotificationPayload(Map<String, String> payload) {
+    final type = payload['type'];
+    if (type == 'todo') {
+      final context = _rootNavKey.currentContext;
+      if (context == null) {
+        return;
+      }
+      GoRouter.of(context).go('/home/todo');
+    }
   }
 
   @override

--- a/lib/util/flutter/notifications/local_notifs.dart
+++ b/lib/util/flutter/notifications/local_notifs.dart
@@ -36,6 +36,7 @@ class LocalNotifs {
   DesktopNotifScheduler? _desktop;
   var _inited = false;
   var _iana = 'UTC';
+  void Function(Map<String, String> payload)? onNotificationPayload;
 
   factory LocalNotifs() => _instance;
 
@@ -72,9 +73,11 @@ class LocalNotifs {
     await _fln.initialize(
       settings: init,
       onDidReceiveNotificationResponse: (resp) {
-        // decode payload and route if needed
-        _decodePayload(resp.payload);
-        // TODO(chat-gpt): route using data['type'], data['id']
+        final data = _decodePayload(resp.payload);
+        if (data.isEmpty) {
+          return;
+        }
+        onNotificationPayload?.call(data);
       },
     );
 


### PR DESCRIPTION
Implements notification payload routing for todo reminders.

Changes:
- expose `onNotificationPayload` callback in local notifications service
- decode payload and invoke callback on notification response
- wire callback in app root to navigate todo payloads to `/home/todo`

Validation:
- targeted analyze on touched files