### PR TITLE
#213 Prevent invoice Sent text clipping

### DIFF
--- a/lib/ui/invoicing/list_invoice_card.dart
+++ b/lib/ui/invoicing/list_invoice_card.dart
@@ -44,6 +44,8 @@ class ListInvoiceCard extends StatelessWidget {
         HMBLinkInternal(
           label:
               '''Job: #${invoiceDetails.job.id} - ${invoiceDetails.job.summary} ''',
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
           navigateTo: () async => FullPageListJobCard(invoiceDetails.job),
         ),
       Text(

--- a/lib/ui/widgets/hmb_link_internal.dart
+++ b/lib/ui/widgets/hmb_link_internal.dart
@@ -16,10 +16,14 @@ import 'package:flutter/material.dart';
 class HMBLinkInternal extends StatelessWidget {
   final String label;
   final Future<Widget> Function() navigateTo;
+  final int? maxLines;
+  final TextOverflow? overflow;
 
   const HMBLinkInternal({
     required this.label,
     required this.navigateTo,
+    this.maxLines,
+    this.overflow,
     super.key,
   });
 
@@ -35,6 +39,8 @@ class HMBLinkInternal extends StatelessWidget {
     },
     child: Text(
       label,
+      maxLines: maxLines,
+      overflow: overflow,
       style: const TextStyle(
         color: Colors.green,
         decoration: TextDecoration.underline,


### PR DESCRIPTION
## Summary
- add optional `maxLines`/`overflow` support to `HMBLinkInternal`
- constrain the invoice job link to a single line with ellipsis
- prevent long job summaries from pushing the `Sent` line out of the fixed-height invoice list card

## Validation
- `flutter analyze lib/ui/widgets/hmb_link_internal.dart lib/ui/invoicing/list_invoice_card.dart` (pass)
- `dart MCP run_tests` on `test/dao/dao_job_test.dart` (fails due to existing test harness issue: `Bad state: Can't call test() once tests have begun running`)

Fixes #213