### PR TITLE
#205 Remove quote line item edit action

### DIFF
--- a/lib/ui/quoting/quote_details_screen.dart
+++ b/lib/ui/quoting/quote_details_screen.dart
@@ -19,16 +19,13 @@ import 'package:strings/strings.dart';
 
 import '../../dao/dao.g.dart';
 import '../../entity/quote.dart';
-import '../../entity/quote_line.dart';
 import '../../util/dart/format.dart';
 import '../crud/milestone/edit_milestone_payment.dart';
 import '../dialog/email_dialog_for_job.dart';
-import '../widgets/icons/hmb_edit_icon.dart';
 import '../widgets/layout/layout.g.dart';
 import '../widgets/media/pdf_preview.dart';
 import '../widgets/text/hmb_text_themes.dart';
 import '../widgets/widgets.g.dart' hide StatefulBuilder;
-import 'edit_quote_line_dialog.dart';
 import 'generate_quote_pdf.dart';
 import 'quote_details.dart';
 import 'select_billing_contact_dialog.dart';
@@ -202,23 +199,6 @@ class _QuoteDetailsScreenState extends DeferredState<QuoteDetailsScreen> {
                                   '''Status: ${line.lineChargeableStatus.description}''',
                                 ),
                               ],
-                            ),
-                            trailing: HMBEditIcon(
-                              onPressed: () async {
-                                final editedLine = await showDialog<QuoteLine>(
-                                  context: context,
-                                  builder: (_) =>
-                                      EditQuoteLineDialog(line: line),
-                                );
-                                if (editedLine != null) {
-                                  await DaoQuoteLine().update(editedLine);
-                                  await DaoQuote().recalculateTotal(
-                                    editedLine.quoteId,
-                                  );
-                                  await _refresh();
-                                }
-                              },
-                              hint: 'Edit Quote Line',
                             ),
                           ),
                         )

--- a/test/ui/quoting/quote_details_screen_test.dart
+++ b/test/ui/quoting/quote_details_screen_test.dart
@@ -91,10 +91,12 @@ void main() {
       MaterialApp(home: QuoteDetailsScreen(quoteId: quoteId)),
     );
     expect(tester.takeException(), isNull);
+    await waitForText(tester, 'Line 1');
 
     expect(find.text('Reject'), findsNothing);
     expect(find.text('Unreject'), findsNothing);
     expect(find.text('Reject Quote Group'), findsNothing);
+    expect(find.byIcon(Icons.edit), findsNothing);
   });
 
   testWidgets('create milestones and invoice actions show', (tester) async {


### PR DESCRIPTION
## Summary
- remove quote line item edit controls from quote details screen
- remove quote line item edit dialog imports from quote details screen
- add a widget assertion that quote details no longer shows edit icons for quote lines

## Validation
- attempted: `flutter test test/ui/quoting/quote_details_screen_test.dart`
- blocked in this environment by missing local path dependency `../flutter_timezone` during dependency resolution