### PR TITLE
#195 Show customer name on Today todo cards

### DIFF
--- a/lib/ui/scheduling/today/today_page.dart
+++ b/lib/ui/scheduling/today/today_page.dart
@@ -320,6 +320,19 @@ class TodayPageState extends DeferredState<TodayPage> {
             Expanded(child: HMBTextHeadline2(todo.title)),
           ],
         ),
+        if (todo.parentType == ToDoParentType.job)
+          FutureBuilderEx<Customer?>(
+            future: DaoCustomer().getByJob(todo.parentId!),
+            builder: (context, customer) => HMBOneOf(
+              condition: customer == null,
+              onTrue: const HMBEmpty(),
+              onFalse: HMBPadding(
+                left: 8,
+                right: 8,
+                child: HMBTextLine('Customer: ${customer!.name}'),
+              ),
+            ),
+          ),
         ToDoCard(todo, (todo) => onChange()),
       ],
     ),


### PR DESCRIPTION
## Summary
- show the related customer name for job-linked todos in the Today page list
- keeps existing todo card behavior while adding customer context above the card

## Validation
- not run in this environment