### PR TITLE
#145 Mark job awaiting approval when quote is sent

### DIFF
--- a/lib/ui/quoting/quote_details_screen.dart
+++ b/lib/ui/quoting/quote_details_screen.dart
@@ -351,6 +351,7 @@ class _QuoteDetailsScreenState extends DeferredState<QuoteDetailsScreen> {
           onSent: () async {
             if (_quote.state != QuoteState.approved) {
               await DaoQuote().markQuoteSent(_quote.id);
+              await DaoJob().markAwaitingApproval(job);
               await _refresh();
             }
           },


### PR DESCRIPTION
## Summary
- when a quote is sent from quote details, also call `DaoJob().markAwaitingApproval(job)`
- keeps existing guard logic (does not alter already approved quotes)

## Validation
- not run in this environment