### PR TITLE
#269 Stabilize shopping list scrolling with keyed items

### DIFF
--- a/lib/ui/task_items/list_shopping_screen.dart
+++ b/lib/ui/task_items/list_shopping_screen.dart
@@ -243,8 +243,12 @@ class ShoppingScreenState extends DeferredState<ShoppingScreen> {
                         ? ListView.builder(
                             padding: const EdgeInsets.all(8),
                             itemCount: _taskItems.length,
-                            itemBuilder: (c, i) =>
-                                _buildShoppingItem(c, _taskItems[i]),
+                            itemBuilder: (c, i) => KeyedSubtree(
+                              key: ValueKey(
+                                '${_selectedMode.name}-${_taskItems[i].taskItem.id}',
+                              ),
+                              child: _buildShoppingItem(c, _taskItems[i]),
+                            ),
                           )
                         : GridView.builder(
                             padding: const EdgeInsets.all(8),
@@ -255,8 +259,12 @@ class ShoppingScreenState extends DeferredState<ShoppingScreen> {
                                   mainAxisExtent: 352,
                                 ),
                             itemCount: _taskItems.length,
-                            itemBuilder: (c, i) =>
-                                _buildShoppingItem(c, _taskItems[i]),
+                            itemBuilder: (c, i) => KeyedSubtree(
+                              key: ValueKey(
+                                '${_selectedMode.name}-${_taskItems[i].taskItem.id}',
+                              ),
+                              child: _buildShoppingItem(c, _taskItems[i]),
+                            ),
                           );
                   },
                 );


### PR DESCRIPTION
## Summary
- add stable keys to shopping list/grid items using mode + task item id
- prevent Flutter from reusing mismatched item elements when cards vary by mode/content
- improves scroll stability when moving up/down through shopping items

## Validation
- not run in this environment