### PR TITLE
#259 Rename inherited task billing type label

### DIFF
--- a/lib/ui/crud/task/edit_task_screen.dart
+++ b/lib/ui/crud/task/edit_task_screen.dart
@@ -178,7 +178,7 @@ class _TaskEditScreenState extends State<TaskEditScreen>
     ),
   );
 
-  final inheritedOption = BillingTypeOption(null, 'Inherited');
+  final inheritedOption = BillingTypeOption(null, "Same as job's");
 
   Widget _chooseBillingType() =>
       HMBDroplist<BillingTypeOption>(


### PR DESCRIPTION
## Summary
- rename the task billing type dropdown fallback label from `Inherited` to `Same as job's`
- leave billing behavior unchanged (`null` still means inherit from job)

## Testing
- not run (label-only UI text change)

Closes #259