### PR TITLE
#215 Hide rejected/completed jobs from today and schedule

### DIFF
--- a/lib/dao/dao_job_activity.dart
+++ b/lib/dao/dao_job_activity.dart
@@ -12,6 +12,7 @@
 */
 
 import '../entity/job_activity.dart';
+import '../entity/job.dart';
 import '../util/dart/local_date.dart';
 import 'dao.dart';
 
@@ -44,17 +45,26 @@ class DaoJobActivity extends Dao<JobActivity> {
 
     final start = date.startOfDay();
     final end = date.endOfDay();
-    final results = await db.query(
-      tableName,
-      where:
-          '''(start_date >= ? AND start_date < ?) OR (end_date > ? AND end_date <= ?)''',
-      whereArgs: <Object>[
+    final results = await db.rawQuery(
+      '''
+SELECT ja.*
+  FROM $tableName ja
+  JOIN job j ON ja.job_id = j.id
+ WHERE (
+        (ja.start_date >= ? AND ja.start_date < ?)
+        OR (ja.end_date > ? AND ja.end_date <= ?)
+       )
+   AND j.status_id NOT IN (?, ?)
+ ORDER BY ja.start_date ASC
+''',
+      [
         start.toIso8601String(),
         end.toIso8601String(),
         start.toIso8601String(),
         end.toIso8601String(),
+        JobStatus.rejected.id,
+        JobStatus.completed.id,
       ],
-      orderBy: 'start_date ASC', // ← next activity first
     );
 
     // Convert each row into a JobActivity
@@ -71,17 +81,26 @@ class DaoJobActivity extends Dao<JobActivity> {
   ) async {
     final db = withoutTransaction();
 
-    final results = await db.query(
-      tableName,
-      where:
-          '''(start_date >= ? AND start_date < ?) OR (end_date > ? AND end_date <= ?)''',
-      whereArgs: <Object>[
+    final results = await db.rawQuery(
+      '''
+SELECT ja.*
+  FROM $tableName ja
+  JOIN job j ON ja.job_id = j.id
+ WHERE (
+        (ja.start_date >= ? AND ja.start_date < ?)
+        OR (ja.end_date > ? AND ja.end_date <= ?)
+       )
+   AND j.status_id NOT IN (?, ?)
+ ORDER BY ja.start_date ASC
+''',
+      <Object>[
         start.toIso8601String(),
         end.toIso8601String(),
         start.toIso8601String(),
         end.toIso8601String(),
+        JobStatus.rejected.id,
+        JobStatus.completed.id,
       ],
-      orderBy: 'start_date ASC', // ← next activity first
     );
 
     // Convert each row into a JobActivity

--- a/lib/dao/dao_todo.dart
+++ b/lib/dao/dao_todo.dart
@@ -1,5 +1,6 @@
 import 'package:sqflite_common/sqlite_api.dart';
 
+import '../entity/job.dart';
 import '../entity/todo.dart';
 import '../util/dart/local_date.dart';
 import 'dao.g.dart';
@@ -151,20 +152,29 @@ class DaoToDo extends Dao<ToDo> {
     final endOfDate = dueBy.endOfDay();
     final endIso = endOfDate.toIso8601String();
 
-    final rows = await db.query(
-      tableName,
-      where: '''
-      status = ?
-      AND due_date IS NOT NULL
-      AND (
-        due_date <= ?              
-      )
-    ''',
-      whereArgs: [
+    final rows = await db.rawQuery(
+      '''
+SELECT td.*
+  FROM $tableName td
+  LEFT JOIN job j
+    ON td.parent_type = ? AND td.parent_id = j.id
+ WHERE td.status = ?
+   AND td.due_date IS NOT NULL
+   AND td.due_date <= ?
+   AND (
+        td.parent_type != ?
+        OR j.status_id NOT IN (?, ?)
+   )
+ ORDER BY td.due_date ASC, td.created_date ASC
+''',
+      [
+        ToDoParentType.job.name,
         ToDoStatus.open.name,
         endIso, // today upper bound
+        ToDoParentType.job.name,
+        JobStatus.rejected.id,
+        JobStatus.completed.id,
       ],
-      orderBy: 'due_date ASC, created_date ASC',
     );
 
     return rows.map(ToDo.fromMap).toList();


### PR DESCRIPTION
## Summary
- filter schedule activity queries to exclude jobs in `rejected` and `completed` states
- filter Today todo query so job-linked todos for rejected/completed jobs are excluded
- keep non-job todos unaffected

## Scope
- `DaoJobActivity.getActivitiesForDate`
- `DaoJobActivity.getActivitiesInRange`
- `DaoToDo.getDueByDate`

## Testing
- not run

Closes #215