### PR TITLE
#220 Recover photo sync after communication errors

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 import 'package:toastification/toastification.dart';
 
 import 'api/ihserver/booking_request_sync_service.dart';
+import 'database/management/backup_providers/google_drive/background_backup/photo_sync_service.dart';
 import 'ui/nav/dashboards/dashboard.dart';
 import 'ui/nav/nav.g.dart';
 import 'ui/widgets/blocking_ui.dart';
@@ -113,6 +114,7 @@ class _HmbAppState extends State<HmbApp> with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
       unawaited(_syncBookings());
+      unawaited(PhotoSyncService().resumeIfNeeded());
     }
   }
 


### PR DESCRIPTION
## Summary
- replace raw isolate error output with user-friendly sync status messages
- add bounded automatic retries for transient photo-sync communication errors
- add `resumeIfNeeded()` in `PhotoSyncService` to restart pending sync work safely
- trigger photo-sync resume on app foreground (`AppLifecycleState.resumed`)

## Validation
- `flutter analyze` (no analyzer errors)

Closes #220