### PR TITLE
#191 Prevent job edit from auto-advancing status

### DIFF
--- a/lib/ui/crud/job/edit_job_card.dart
+++ b/lib/ui/crud/job/edit_job_card.dart
@@ -114,7 +114,7 @@ class _EditJobCardState extends DeferredState<EditJobCard> {
   @override
   Future<void> asyncInitState() async {
     if (widget.job != null) {
-      await DaoJob().markActive(widget.job!.id);
+      await DaoJob().markLastActive(widget.job!.id);
     }
   }
 
@@ -326,7 +326,7 @@ You can set a default booking fee from System | Billing screen''');
       if ((await DaoSystem().get()).getOperatingHours().noOpenDays()) {
         HMBToast.error(
           'Before you Schedule a job, you must first set your '
-          "opening hours from the 'System | Business' page.",
+              "opening hours from the 'System | Business' page.",
         );
         return;
       }


### PR DESCRIPTION
## Summary
- stop using `DaoJob().markActive(...)` when opening the job edit card
- add `DaoJob().markLastActive(...)` for last-access bookkeeping without status transitions
- keep `markActive(...)` behavior for explicit activation flows

## Why
- opening edit on a pre-start job was automatically moving it to `inProgress`
- this aligns edit behavior with user intent and avoids unintended lifecycle jumps

## Validation
- `flutter analyze` (no analyzer errors)

Closes #191