### PR TITLE
#199 Add system default profit margin and apply to new task items

### DIFF
--- a/lib/ui/crud/check_list/edit_task_item_screen.dart
+++ b/lib/ui/crud/check_list/edit_task_item_screen.dart
@@ -33,6 +33,7 @@ import '../../../entity/task.dart';
 import '../../../entity/task_item.dart';
 import '../../../entity/task_item_type.dart';
 import '../../../util/dart/fixed_ex.dart';
+import '../../../util/dart/app_settings.dart';
 import '../../../util/dart/measurement_type.dart';
 import '../../../util/dart/money_ex.dart';
 import '../../../util/flutter/platform_ex.dart';
@@ -149,6 +150,7 @@ class _TaskItemEditScreenState extends DeferredState<TaskItemEditScreen>
   @override
   Future<System> asyncInitState() async {
     final system = await DaoSystem().get();
+    final defaultMarginText = await AppSettings.getDefaultProfitMarginText();
     var selectedUnits = June.getState(SelectedUnits.new).selected;
 
     June.getState(SelectedSupplier.new).selected = currentEntity?.supplierId;
@@ -169,6 +171,11 @@ class _TaskItemEditScreenState extends DeferredState<TaskItemEditScreen>
         currentEntity?.measurementType;
     June.getState(SelectedCheckListItemType.new).selected =
         currentEntity?.itemType;
+
+    if (currentEntity == null && _marginController.text.trim().isEmpty) {
+      _marginController.text = defaultMarginText;
+      _calculateChargeFromMargin(defaultMarginText);
+    }
     return system;
   }
 

--- a/lib/ui/dialog/add_task_item.dart
+++ b/lib/ui/dialog/add_task_item.dart
@@ -19,6 +19,7 @@ import '../../entity/entity.g.dart';
 import '../../entity/helpers/charge_mode.dart';
 import '../../util/dart/measurement_type.dart';
 import '../../util/dart/money_ex.dart';
+import '../../util/dart/app_settings.dart';
 import '../../util/dart/units.dart';
 import '../widgets/fields/hmb_text_field.dart';
 import '../widgets/hmb_button.dart';
@@ -162,6 +163,9 @@ Future<void> _addTaskItem({
       selectedItemType != null) {
     final quantity = Fixed.tryParse(quantityController.text) ?? Fixed.one;
     final unitCost = MoneyEx.tryParse(unitCostController.text);
+    final defaultMargin =
+        Percentage.tryParse(await AppSettings.getDefaultProfitMarginText()) ??
+        Percentage.zero;
 
     // Create and insert the new TaskItem
     final newItem = TaskItem.forInsert(
@@ -176,7 +180,7 @@ Future<void> _addTaskItem({
       dimension2: Fixed.zero,
       dimension3: Fixed.zero,
       labourEntryMode: LabourEntryMode.hours,
-      margin: Percentage.zero,
+      margin: defaultMargin,
       measurementType: MeasurementType.length,
       units: Units.defaultUnits,
       url: '',

--- a/lib/util/dart/app_settings.dart
+++ b/lib/util/dart/app_settings.dart
@@ -18,6 +18,8 @@ import 'paths.dart';
 class AppSettings {
   static const photoCacheMaxMbDefault = 100;
   static const _photoCacheMaxMbKey = 'photoCacheMaxMb';
+  static const defaultProfitMarginTextDefault = '0';
+  static const _defaultProfitMarginTextKey = 'defaultProfitMarginText';
 
   static Future<int> getPhotoCacheMaxMb() async {
     final settings = SettingsYaml.load(pathToSettings: await getSettingsPath());
@@ -41,6 +43,29 @@ class AppSettings {
     final safeValue = megabytes <= 0 ? photoCacheMaxMbDefault : megabytes;
     final settings = SettingsYaml.load(pathToSettings: await getSettingsPath());
     settings[_photoCacheMaxMbKey] = safeValue;
+    await settings.save();
+  }
+
+  static Future<String> getDefaultProfitMarginText() async {
+    final settings = SettingsYaml.load(pathToSettings: await getSettingsPath());
+    final value = settings[_defaultProfitMarginTextKey];
+
+    if (value is String && value.trim().isNotEmpty) {
+      return value.trim();
+    }
+    if (value is num) {
+      return value.toString();
+    }
+
+    return defaultProfitMarginTextDefault;
+  }
+
+  static Future<void> setDefaultProfitMarginText(String value) async {
+    final sanitized = value.trim().isEmpty
+        ? defaultProfitMarginTextDefault
+        : value.trim();
+    final settings = SettingsYaml.load(pathToSettings: await getSettingsPath());
+    settings[_defaultProfitMarginTextKey] = sanitized;
     await settings.save();
   }
 }


### PR DESCRIPTION
## Summary
- add a configurable default profit margin in System Billing settings
- persist default profit margin in app settings
- apply default margin when creating task items via add-item flows
- use default margin as the initial value when editing/creating task items

## Validation
- `flutter analyze` (no analyzer errors)

Closes #199