### PR TITLE
#353 Use contact name in job notice greetings

### DIFF
--- a/lib/ui/dialog/send_notice_for_job_dialog.dart
+++ b/lib/ui/dialog/send_notice_for_job_dialog.dart
@@ -30,6 +30,18 @@ import '../widgets/select/hmb_select_mobile_multi.dart';
 
 enum _Channel { email, sms }
 
+String noticeEmailGreetingForContact(Contact? contact) {
+  final name = _noticeContactName(contact);
+  return Strings.isBlank(name) ? 'Hello,' : '$name,';
+}
+
+String noticeSmsGreetingForContact(Contact? contact) {
+  final name = _noticeContactName(contact);
+  return Strings.isBlank(name) ? 'Hi,' : 'Hi $name,';
+}
+
+String _noticeContactName(Contact? contact) => contact?.fullname.trim() ?? '';
+
 class SendNoticeForJobDialog extends StatefulWidget {
   final Job job;
 
@@ -57,22 +69,17 @@ class SendNoticeForJobDialog extends StatefulWidget {
   @override
   State<SendNoticeForJobDialog> createState() => _SendNoticeForJobDialogState();
 
-  static Future<void> show(
+  static Future<bool> show(
     BuildContext context,
     Job job,
     JobActivity jobActivity,
-  ) async {
-    final sent = await showDialog<bool>(
-      context: context,
-      builder: (_) => SendNoticeForJobDialog(
-        job: job,
-        jobActivity: jobActivity, // optional
-      ),
-    );
-    if (sent ?? false) {
-      // refresh UI if needed
-    }
-  }
+  ) async =>
+      await showDialog<bool>(
+        context: context,
+        builder: (_) =>
+            SendNoticeForJobDialog(job: job, jobActivity: jobActivity),
+      ) ??
+      false;
 }
 
 class _SendNoticeForJobDialogState
@@ -91,6 +98,7 @@ class _SendNoticeForJobDialogState
   @override
   Future<void> asyncInitState() async {
     _system = await DaoSystem().get();
+    final primary = await _primaryContactForJob(widget.job);
 
     // Prefill subject/body from schedule if available.
     final scheduleText = await _buildScheduleLine(widget.job);
@@ -98,7 +106,7 @@ class _SendNoticeForJobDialogState
     final defaultBody =
         widget.initialBody ??
         '''
-Hello,
+${noticeEmailGreetingForContact(primary)}
 
 This is a notice for your scheduled job.
 
@@ -118,12 +126,13 @@ ${Strings.isNotBlank(_system.businessNumber) ? '${Strings.orElseOnBlank(_system.
 
     // SMS body is shorter; keep it simple and template-friendly.
     _smsBodyCtl = TextEditingController(
-      text: 'Hi, your job is scheduled. $scheduleText\n${_system.businessName}',
+      text:
+          '${noticeSmsGreetingForContact(primary)} your job is scheduled. '
+          '$scheduleText\n${_system.businessName}',
     );
 
     // Smart default: prefer SMS tab and preselect primary contact mobile.
     _channel = _Channel.sms;
-    final primary = await _primaryContactForJob(widget.job);
     if (primary != null && Strings.isNotBlank(primary.mobileNumber)) {
       _toMobiles = [primary.mobileNumber];
     }

--- a/lib/ui/scheduling/job_activity_dialog.dart
+++ b/lib/ui/scheduling/job_activity_dialog.dart
@@ -183,7 +183,7 @@ class _JobActivityDialogState extends DeferredState<JobActivityDialog> {
                   Text('Notice sent on: ${formatDateTime(_noticeSentDate!)}'),
 
                 // Contact option
-                if (widget.isEditing || _selectedJob.jobId != null)
+                if (widget.isEditing)
                   HMBButtonSecondary(
                     onPressed: _showContactOptions,
                     label: 'Send Notice',
@@ -629,7 +629,10 @@ class _JobActivityDialogState extends DeferredState<JobActivityDialog> {
     Job job,
     JobActivity jobActivity,
   ) async {
-    await SendNoticeForJobDialog.show(context, job, jobActivity);
+    final sent = await SendNoticeForJobDialog.show(context, job, jobActivity);
+    if (!sent) {
+      return;
+    }
 
     // Record the date the notice was sent
     setState(() {

--- a/test/ui/dialog/send_notice_for_job_dialog_test.dart
+++ b/test/ui/dialog/send_notice_for_job_dialog_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/entity/contact.dart';
+import 'package:hmb/ui/dialog/send_notice_for_job_dialog.dart';
+
+void main() {
+  group('scheduled job notice greetings', () {
+    test('uses the contact full name in the email greeting', () {
+      final contact = Contact.forInsert(
+        firstName: 'Ada',
+        surname: 'Lovelace',
+        mobileNumber: '0400000000',
+        landLine: '',
+        officeNumber: '',
+        emailAddress: 'ada@example.com',
+      );
+
+      expect(noticeEmailGreetingForContact(contact), 'Ada Lovelace,');
+    });
+
+    test('uses the contact full name in the SMS greeting', () {
+      final contact = Contact.forInsert(
+        firstName: 'Ada',
+        surname: 'Lovelace',
+        mobileNumber: '0400000000',
+        landLine: '',
+        officeNumber: '',
+        emailAddress: 'ada@example.com',
+      );
+
+      expect(noticeSmsGreetingForContact(contact), 'Hi Ada Lovelace,');
+    });
+
+    test('falls back when there is no contact name', () {
+      expect(noticeEmailGreetingForContact(null), 'Hello,');
+      expect(noticeSmsGreetingForContact(null), 'Hi,');
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #353.

Updates the scheduled job notice defaults so generated messages address the selected job contact by name instead of starting with a generic greeting.

## Changes

- Resolve the primary job contact before building the default notice text.
- Use the contact full name in the default email greeting.
- Use the contact full name in the default SMS greeting.
- Preserve the existing generic fallback when no contact is available.
- Hide `Send Notice` while creating an unsaved schedule event, because there is no persisted activity to stamp or send from yet.
- Only update `noticeSentDate` after the notice dialog reports that a send was actually initiated.
- Add focused tests for named-contact and no-contact greeting behavior.

## Validation

Automated checks:

```bash
flutter analyze lib/ui/dialog/send_notice_for_job_dialog.dart lib/ui/scheduling/job_activity_dialog.dart test/ui/dialog/send_notice_for_job_dialog_test.dart
flutter test test/ui/dialog/send_notice_for_job_dialog_test.dart
```

Live fdb verification on Pixel 5 using the local fixed fdb checkout:

```bash
dart run bin/fdb.dart launch --device 11181FDD40047B --project /home/bsutton/git/hmb
dart run bin/fdb.dart --session-dir /home/bsutton/git/hmb/.fdb doctor
dart run bin/fdb.dart --session-dir /home/bsutton/git/hmb/.fdb describe
```

Previously verified flow:

- Opened Schedule from the dashboard.
- Tapped the schedule body to create a future scheduled event.
- Selected job `2nd job` with contact `One`.
- Saved the event and reopened it from the schedule body.
- Opened `Send Notice` and selected the contact method.
- Verified the SMS message starts with `Hi One, ...`.
- Switched to the Email tab and verified the body starts with `One,` instead of `Hello,`.

Additional validation for the follow-up fixes:

- Confirmed `Send Notice` no longer appears while adding an unsaved event.
- Confirmed cancelling the notice dialog does not mark the scheduled event as notice-sent.