### PR TITLE
Fix #423: cover quote sent job status

### DIFF
--- a/test/dao/dao_quote_withdraw_test.dart
+++ b/test/dao/dao_quote_withdraw_test.dart
@@ -37,4 +37,56 @@ void main() {
     final quote = await DaoQuote().getById(quoteId);
     expect(quote?.state, QuoteState.withdrawn);
   });
+
+  test('markQuoteSent moves prospecting job to awaiting approval', () async {
+    final job = await createJobWithCustomer(
+      billingType: BillingType.fixedPrice,
+      hourlyRate: Money.fromInt(5000, isoCode: 'AUD'),
+    );
+    expect(job.status, JobStatus.prospecting);
+
+    final quoteId = await DaoQuote().insert(
+      Quote.forInsert(
+        jobId: job.id,
+        summary: 'Prospecting job quote',
+        description: 'Quote to test job status update',
+        totalAmount: Money.fromInt(25000, isoCode: 'AUD'),
+      ),
+    );
+
+    await DaoQuote().markQuoteSent(quoteId);
+
+    final quote = await DaoQuote().getById(quoteId);
+    expect(quote?.state, QuoteState.sent);
+    expect(quote?.dateSent, isNotNull);
+
+    final updatedJob = await DaoJob().getById(job.id);
+    expect(updatedJob?.status, JobStatus.awaitingApproval);
+  });
+
+  test('markQuoteSent leaves active jobs unchanged', () async {
+    final job = await createJobWithCustomer(
+      billingType: BillingType.fixedPrice,
+      hourlyRate: Money.fromInt(5000, isoCode: 'AUD'),
+    );
+    final activeJob = job.copyWith(status: JobStatus.inProgress);
+    await DaoJob().update(activeJob);
+
+    final quoteId = await DaoQuote().insert(
+      Quote.forInsert(
+        jobId: job.id,
+        summary: 'Active job quote',
+        description: 'Quote to test guarded job status update',
+        totalAmount: Money.fromInt(25000, isoCode: 'AUD'),
+      ),
+    );
+
+    await DaoQuote().markQuoteSent(quoteId);
+
+    final quote = await DaoQuote().getById(quoteId);
+    expect(quote?.state, QuoteState.sent);
+
+    final updatedJob = await DaoJob().getById(job.id);
+    expect(updatedJob?.status, JobStatus.inProgress);
+  });
 }


### PR DESCRIPTION
## Summary
- add DAO coverage for quote sent status updates on prospecting jobs
- add guarded coverage that active jobs are not moved back to awaiting approval

Fixes #423

## Tests
- flutter test test/dao/dao_quote_withdraw_test.dart
- flutter analyze
- git diff --check