### PR TITLE
Fix #421: add receipt supplier date filters

### DIFF
--- a/lib/dao/dao_receipt.dart
+++ b/lib/dao/dao_receipt.dart
@@ -44,6 +44,7 @@ class DaoReceipt extends Dao<Receipt> {
 
   /// Filter receipts by optional criteria
   Future<List<Receipt>> getByFilter({
+    String? supplierFilter,
     int? jobId,
     int? supplierId,
     DateTime? dateFrom,
@@ -62,6 +63,19 @@ class DaoReceipt extends Dao<Receipt> {
     if (supplierId != null) {
       where.add('supplier_id = ?');
       args.add(supplierId);
+    }
+    if (supplierFilter != null && supplierFilter.trim().isNotEmpty) {
+      final like = '%${supplierFilter.trim()}%';
+      where.add('''
+supplier_id IN (
+  SELECT id
+  FROM supplier
+  WHERE name LIKE ?
+  OR description LIKE ?
+  OR service LIKE ?
+)
+''');
+      args.addAll([like, like, like]);
     }
     if (dateFrom != null) {
       where.add('receipt_date >= ?');

--- a/lib/ui/crud/receipt/list_receipt_screen.dart
+++ b/lib/ui/crud/receipt/list_receipt_screen.dart
@@ -20,7 +20,9 @@ import '../../../entity/entity.g.dart';
 import '../../../util/flutter/flutter_util.g.dart';
 import '../../widgets/layout/layout.g.dart';
 import '../../widgets/media/photo_gallery.dart';
+import '../../widgets/select/select.g.dart';
 import '../../widgets/text/text.g.dart';
+import '../../widgets/widgets.g.dart';
 import '../base_full_screen/base_full_screen.g.dart';
 import 'edit_receipt_screen.dart';
 
@@ -32,12 +34,119 @@ class ReceiptListScreen extends StatefulWidget {
 }
 
 class _ReceiptListScreenState extends State<ReceiptListScreen> {
+  final _supplierFilter = SelectedSupplier();
+  DateTime? _dateFrom;
+  DateTime? _dateTo;
+
+  Future<List<Receipt>> _fetchFilteredReceipts(String? filter) =>
+      DaoReceipt().getByFilter(
+        supplierFilter: filter,
+        supplierId: _supplierFilter.selected,
+        dateFrom: _startOfDay(_dateFrom),
+        dateTo: _endOfDay(_dateTo),
+      );
+
+  DateTime? _startOfDay(DateTime? date) {
+    if (date == null) {
+      return null;
+    }
+    return DateTime(date.year, date.month, date.day);
+  }
+
+  DateTime? _endOfDay(DateTime? date) {
+    if (date == null) {
+      return null;
+    }
+    return DateTime(date.year, date.month, date.day, 23, 59, 59, 999);
+  }
+
+  Future<void> _selectDate({
+    required DateTime? current,
+    required ValueChanged<DateTime?> onSelected,
+    required VoidCallback onChange,
+  }) async {
+    final picked = await showDatePicker(
+      context: context,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+      initialDate: current ?? DateTime.now(),
+    );
+    if (picked != null) {
+      onSelected(picked);
+      onChange();
+    }
+  }
+
+  Widget _dateFilterTile({
+    required String title,
+    required DateTime? date,
+    required ValueChanged<DateTime?> onSelected,
+    required VoidCallback onChange,
+  }) => ListTile(
+    key: ValueKey('$title-$date'),
+    title: Text(title),
+    subtitle: Text(date == null ? 'Any date' : formatDate(date)),
+    trailing: Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (date != null)
+          IconButton(
+            tooltip: 'Clear $title',
+            onPressed: () {
+              onSelected(null);
+              onChange();
+            },
+            icon: const Icon(Icons.clear),
+          ),
+        const Icon(Icons.calendar_today),
+      ],
+    ),
+    onTap: () =>
+        _selectDate(current: date, onSelected: onSelected, onChange: onChange),
+  );
+
+  Widget _buildFilterSheet(void Function() onChange) => ListView(
+    padding: const EdgeInsets.all(16),
+    shrinkWrap: true,
+    children: [
+      HMBSelectSupplier(
+        selectedSupplier: _supplierFilter,
+        onSelected: (_) => onChange(),
+      ).help('Filter by Supplier', 'Only show receipts for this supplier'),
+      const SizedBox(height: 16),
+      _dateFilterTile(
+        title: 'Receipt Date From',
+        date: _dateFrom,
+        onSelected: (date) => setState(() => _dateFrom = date),
+        onChange: onChange,
+      ),
+      _dateFilterTile(
+        title: 'Receipt Date To',
+        date: _dateTo,
+        onSelected: (date) => setState(() => _dateTo = date),
+        onChange: onChange,
+      ),
+    ],
+  );
+
+  void _clearFilters() {
+    _supplierFilter.selected = null;
+    _dateFrom = null;
+    _dateTo = null;
+  }
+
   @override
   Widget build(BuildContext context) => EntityListScreen<Receipt>(
     entityNameSingular: 'Receipt',
     entityNamePlural: 'Receipts',
     dao: DaoReceipt(),
-    fetchList: (_) => DaoReceipt().getByFilter(),
+    fetchList: _fetchFilteredReceipts,
+    filterSheetBuilder: _buildFilterSheet,
+    onFilterReset: _clearFilters,
+    isFilterActive: () =>
+        _supplierFilter.selected != null ||
+        _dateFrom != null ||
+        _dateTo != null,
     onEdit: (receipt) => ReceiptEditScreen(receipt: receipt),
     listCardTitle: _getTitle,
     cardHeight: 480,

--- a/test/dao/dao_receipt_filter_test.dart
+++ b/test/dao/dao_receipt_filter_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/dao/dao.g.dart';
+import 'package:hmb/entity/entity.g.dart';
+import 'package:money2/money2.dart';
+
+import '../database/management/db_utility_test_helper.dart';
+import '../ui/ui_test_helpers.dart';
+
+void main() {
+  setUp(() async {
+    await setupTestDb();
+  });
+
+  tearDown(() async {
+    await tearDownTestDb();
+  });
+
+  test('filters receipts by supplier name search', () async {
+    final job = await createJobWithCustomer(
+      billingType: BillingType.fixedPrice,
+      hourlyRate: Money.fromInt(5000, isoCode: 'AUD'),
+    );
+    final acme = await _insertSupplier('Acme Hardware');
+    final beta = await _insertSupplier('Beta Plumbing');
+
+    await _insertReceipt(
+      jobId: job.id,
+      supplierId: acme.id,
+      receiptDate: DateTime(2026, 1, 1, 10),
+    );
+    await _insertReceipt(
+      jobId: job.id,
+      supplierId: beta.id,
+      receiptDate: DateTime(2026, 1, 2, 10),
+    );
+
+    final receipts = await DaoReceipt().getByFilter(supplierFilter: 'acme');
+
+    expect(receipts, hasLength(1));
+    expect(receipts.single.supplierId, acme.id);
+  });
+
+  test('filters receipts by supplier and receipt date range', () async {
+    final job = await createJobWithCustomer(
+      billingType: BillingType.fixedPrice,
+      hourlyRate: Money.fromInt(5000, isoCode: 'AUD'),
+    );
+    final acme = await _insertSupplier('Acme Hardware');
+    final beta = await _insertSupplier('Beta Plumbing');
+
+    await _insertReceipt(
+      jobId: job.id,
+      supplierId: acme.id,
+      receiptDate: DateTime(2026, 1, 1, 10),
+    );
+    final matching = await _insertReceipt(
+      jobId: job.id,
+      supplierId: acme.id,
+      receiptDate: DateTime(2026, 1, 2, 14),
+    );
+    await _insertReceipt(
+      jobId: job.id,
+      supplierId: beta.id,
+      receiptDate: DateTime(2026, 1, 2, 16),
+    );
+    await _insertReceipt(
+      jobId: job.id,
+      supplierId: acme.id,
+      receiptDate: DateTime(2026, 1, 3, 10),
+    );
+
+    final receipts = await DaoReceipt().getByFilter(
+      supplierId: acme.id,
+      dateFrom: DateTime(2026, 1, 2),
+      dateTo: DateTime(2026, 1, 2, 23, 59, 59, 999),
+    );
+
+    expect(receipts.map((receipt) => receipt.id), [matching.id]);
+  });
+}
+
+Future<Supplier> _insertSupplier(String name) async {
+  final supplier = Supplier.forInsert(
+    name: name,
+    businessNumber: '',
+    description: 'Test supplier',
+    bsb: '',
+    accountNumber: '',
+    service: '',
+  );
+  await DaoSupplier().insert(supplier);
+  return supplier;
+}
+
+Future<Receipt> _insertReceipt({
+  required int jobId,
+  required int supplierId,
+  required DateTime receiptDate,
+}) async {
+  final receipt = Receipt.forInsert(
+    receiptDate: receiptDate,
+    jobId: jobId,
+    supplierId: supplierId,
+    totalExcludingTax: Money.fromInt(10000, isoCode: 'AUD'),
+    tax: Money.fromInt(1000, isoCode: 'AUD'),
+    totalIncludingTax: Money.fromInt(11000, isoCode: 'AUD'),
+  );
+  await DaoReceipt().insert(receipt);
+  return receipt;
+}


### PR DESCRIPTION
## Summary
- add supplier-name search support to receipt DAO filtering
- add receipt list advanced filters for supplier and receipt date range
- cover supplier search and combined supplier/date range filtering

Fixes #421

## Tests
- flutter test test/dao/dao_receipt_filter_test.dart
- flutter analyze
- git diff --check