### PR TITLE
Fix #420: label fixed price quotes

### DIFF
--- a/lib/ui/quoting/generate_quote_pdf.dart
+++ b/lib/ui/quoting/generate_quote_pdf.dart
@@ -160,7 +160,7 @@ Future<File> generateQuotePdf(
                       crossAxisAlignment: pw.CrossAxisAlignment.start,
                       children: [
                         pw.Text(
-                          'Quote: ${quote.bestNumber}',
+                          'Fixed Price Quote: ${quote.bestNumber}',
                           style: pw.TextStyle(
                             fontSize: 18,
                             fontWeight: pw.FontWeight.bold,

--- a/lib/ui/quoting/list_quote_screen.dart
+++ b/lib/ui/quoting/list_quote_screen.dart
@@ -150,7 +150,8 @@ class _QuoteListScreenState extends State<QuoteListScreen> {
     entityNamePlural: 'Quotes',
     dao: DaoQuote(),
     listCardTitle: (quote) => Text(
-      'Quote #${quote.id} - Issued: ${formatDate(quote.createdDate)}',
+      'Fixed Price Quote #${quote.id} - '
+      'Issued: ${formatDate(quote.createdDate)}',
       style: const TextStyle(fontWeight: FontWeight.bold),
     ),
     fetchList: _fetchFilteredQuotes,

--- a/lib/ui/quoting/quote_card.dart
+++ b/lib/ui/quoting/quote_card.dart
@@ -158,20 +158,20 @@ class _QuoteCardState extends DeferredState<QuoteCard> {
     await Navigator.of(context).push(
       MaterialPageRoute<void>(
         builder: (context) => PdfPreviewScreen(
-          title: 'Quote #${quote.bestNumber} ${job.summary}',
+          title: 'Fixed Price Quote #${quote.bestNumber} ${job.summary}',
           filePath: quoteFile.path,
           preferredRecipient:
               billingContact?.emailAddress ?? primaryContact.emailAddress,
           emailSubject:
-              '${system.businessName ?? 'Your'} Quote #'
+              '${system.businessName ?? 'Your'} Fixed Price Quote #'
               '${quote.bestNumber}',
           emailBody:
               '''
 ${primaryContact.firstName.trim()},
 
-Please review the attached quote for your job.
+Please review the attached fixed price quote for your job.
 To approve it, reply to this email with:
-"I approve Quote #${quote.bestNumber} for Job ${job.summary}".
+"I approve Fixed Price Quote #${quote.bestNumber} for Job ${job.summary}".
 ''',
           sendEmailDialog:
               ({

--- a/lib/ui/quoting/quote_details_screen.dart
+++ b/lib/ui/quoting/quote_details_screen.dart
@@ -53,7 +53,7 @@ class _QuoteDetailsScreenState extends DeferredState<QuoteDetailsScreen> {
 
   @override
   Widget build(BuildContext context) => Scaffold(
-    appBar: AppBar(title: const Text('Quote Details')),
+    appBar: AppBar(title: const Text('Fixed Price Quote Details')),
     body: DeferredBuilder(
       this,
       builder: (context) => SingleChildScrollView(
@@ -74,7 +74,7 @@ class _QuoteDetailsScreenState extends DeferredState<QuoteDetailsScreen> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          'Quote #${_quote.id}',
+          'Fixed Price Quote #${_quote.id}',
           style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
         ),
         Text('Issued: ${formatDate(_quote.createdDate)}'),

--- a/test/ui/quoting/quote_details_screen_test.dart
+++ b/test/ui/quoting/quote_details_screen_test.dart
@@ -90,6 +90,7 @@ void main() {
     expect(find.text('Unreject'), findsNothing);
     expect(find.text('Reject Quote Group'), findsNothing);
     expect(find.byIcon(Icons.edit), findsNothing);
+    expect(find.text('Fixed Price Quote #$quoteId'), findsOneWidget);
   });
 
   testWidgets('approved quote details render without actions panel', (


### PR DESCRIPTION
## Summary
- label quote list and details screens as fixed price quotes
- label PDF preview, email subject/body, and generated PDF header as fixed price quotes
- add widget coverage for the quote details label

Fixes #420

## Tests
- flutter test test/ui/quoting/quote_details_screen_test.dart test/ui/quoting/quote_card_test.dart
- flutter analyze
- git diff --check