### PR TITLE
Fix #419: persist default estimate margin

### DIFF
--- a/assets/sql/upgrade_list.json
+++ b/assets/sql/upgrade_list.json
@@ -1,4 +1,5 @@
 [
+  "assets/sql/upgrade_scripts/v175.sql",
   "assets/sql/upgrade_scripts/v174.sql",
   "assets/sql/upgrade_scripts/v173.sql",
   "assets/sql/upgrade_scripts/v172.sql",

--- a/assets/sql/upgrade_scripts/v175.sql
+++ b/assets/sql/upgrade_scripts/v175.sql
@@ -1,0 +1,2 @@
+ALTER TABLE system
+ADD COLUMN default_profit_margin INTEGER;

--- a/lib/dao/dao_system.dart
+++ b/lib/dao/dao_system.dart
@@ -18,12 +18,17 @@ import 'package:sqflite_common/sqlite_api.dart';
 import 'package:strings/strings.dart';
 
 import '../entity/system.dart';
-import '../util//dart/exceptions.dart' as hmb;
+import '../util/dart/app_settings.dart';
+import '../util/dart/exceptions.dart' as hmb;
 import 'dao.dart';
 import 'system_secret_store.dart';
 
 class DaoSystem extends Dao<System> {
   static const tableName = 'system';
+  static final defaultProfitMargin = Percentage.fromInt(
+    20000,
+    decimalDigits: 3,
+  );
   final _secretStore = SystemSecretStore();
   DaoSystem() : super(tableName);
   Future<void> createTable(Database db, int version) async {}
@@ -90,6 +95,18 @@ class DaoSystem extends Dao<System> {
     final system = await get();
 
     return system.defaultHourlyRate ?? Money.parse('100', isoCode: 'AUD');
+  }
+
+  Future<Percentage> getDefaultProfitMargin() async {
+    final system = await get();
+    if (system.defaultProfitMargin != null) {
+      return system.defaultProfitMargin!;
+    }
+
+    final legacyMargin = Percentage.tryParse(
+      await AppSettings.getDefaultProfitMarginText(),
+    );
+    return legacyMargin ?? defaultProfitMargin;
   }
 }
 

--- a/lib/entity/system.dart
+++ b/lib/entity/system.dart
@@ -90,6 +90,7 @@ class System extends Entity<System> {
   Money? defaultHourlyRate;
   String? termsUrl;
   Money? defaultBookingFee;
+  Percentage? defaultProfitMargin;
   int? simCardNo;
   String? xeroClientId;
   String? xeroClientSecret;
@@ -151,6 +152,7 @@ class System extends Entity<System> {
     required this.defaultHourlyRate,
     required this.termsUrl,
     required this.defaultBookingFee,
+    required this.defaultProfitMargin,
     required this.simCardNo,
     required this.xeroClientId,
     required this.xeroClientSecret,
@@ -219,6 +221,7 @@ class System extends Entity<System> {
     required this.paymentTermsInDays,
     required this.paymentOptions,
     required this.richTextRemoved,
+    this.defaultProfitMargin,
     this.photoCacheMaxMb = 100,
     this.enableXeroIntegration = true,
     this.preferredUnitSystem = PreferredUnitSystem.metric,
@@ -253,6 +256,7 @@ class System extends Entity<System> {
     Money? defaultHourlyRate,
     String? termsUrl,
     Money? defaultBookingFee,
+    Percentage? defaultProfitMargin,
     int? simCardNo,
     String? xeroClientId,
     String? xeroClientSecret,
@@ -302,6 +306,7 @@ class System extends Entity<System> {
     defaultHourlyRate: defaultHourlyRate ?? this.defaultHourlyRate,
     termsUrl: termsUrl ?? this.termsUrl,
     defaultBookingFee: defaultBookingFee ?? this.defaultBookingFee,
+    defaultProfitMargin: defaultProfitMargin ?? this.defaultProfitMargin,
     simCardNo: simCardNo ?? this.simCardNo,
     xeroClientId: xeroClientId ?? this.xeroClientId,
     xeroClientSecret: xeroClientSecret ?? this.xeroClientSecret,
@@ -366,6 +371,12 @@ class System extends Entity<System> {
       map['default_booking_fee'] as int? ?? 0,
       isoCode: 'AUD',
     ),
+    defaultProfitMargin: map['default_profit_margin'] == null
+        ? null
+        : Percentage.fromInt(
+            map['default_profit_margin'] as int,
+            decimalDigits: 3,
+          ),
     simCardNo: map['sim_card_no'] as int?,
     xeroClientId: map['xero_client_id'] as String?,
     xeroClientSecret: map['xero_client_secret'] as String?,
@@ -463,6 +474,10 @@ class System extends Entity<System> {
     'default_hourly_rate': defaultHourlyRate?.minorUnits.toInt(),
     'terms_url': termsUrl,
     'default_booking_fee': defaultBookingFee?.minorUnits.toInt(),
+    'default_profit_margin': defaultProfitMargin
+        ?.copyWith(decimalDigits: 3)
+        .minorUnits
+        .toInt(),
     'sim_card_no': simCardNo,
     'xero_client_id': xeroClientId,
     'xero_client_secret': xeroClientSecret,

--- a/lib/ui/crud/check_list/edit_task_item_screen.dart
+++ b/lib/ui/crud/check_list/edit_task_item_screen.dart
@@ -32,7 +32,6 @@ import '../../../entity/system.dart';
 import '../../../entity/task.dart';
 import '../../../entity/task_item.dart';
 import '../../../entity/task_item_type.dart';
-import '../../../util/dart/app_settings.dart';
 import '../../../util/dart/fixed_ex.dart';
 import '../../../util/dart/measurement_type.dart';
 import '../../../util/dart/money_ex.dart';
@@ -152,7 +151,8 @@ class _TaskItemEditScreenState extends DeferredState<TaskItemEditScreen>
   @override
   Future<System> asyncInitState() async {
     final system = await DaoSystem().get();
-    final defaultMarginText = await AppSettings.getDefaultProfitMarginText();
+    final defaultMarginText = (await DaoSystem().getDefaultProfitMargin())
+        .toString();
     var selectedUnits = June.getState(SelectedUnits.new).selected;
 
     June.getState(SelectedSupplier.new).selected = currentEntity?.supplierId;

--- a/lib/ui/crud/job/job_creator.dart
+++ b/lib/ui/crud/job/job_creator.dart
@@ -744,6 +744,7 @@ class _JobCreatorState extends State<JobCreator> {
               system.defaultHourlyRate ?? Money.fromInt(0, isoCode: 'AUD'),
           bookingFee:
               system.defaultBookingFee ?? Money.fromInt(0, isoCode: 'AUD'),
+          estimateMargin: await DaoSystem().getDefaultProfitMargin(),
           billingContactId: contact?.id,
           referrerContactId: _selectedReferrerContact?.id,
         );

--- a/lib/ui/crud/system/system_billing_screen.dart
+++ b/lib/ui/crud/system/system_billing_screen.dart
@@ -96,7 +96,7 @@ class SystemBillingScreenState extends DeferredState<SystemBillingScreen> {
       text: system.paymentOptions,
     );
     _defaultProfitMarginController.text =
-        await AppSettings.getDefaultProfitMarginText();
+        (await DaoSystem().getDefaultProfitMargin()).toString();
     _taxDisplayMode = await AppSettings.getTaxDisplayMode();
     _taxLabelController.text = await AppSettings.getTaxLabel();
     _taxRateController.text = await AppSettings.getTaxRatePercentText();
@@ -132,6 +132,14 @@ class SystemBillingScreenState extends DeferredState<SystemBillingScreen> {
 
   Future<bool> save({required bool close}) async {
     if (_formKey.currentState!.validate()) {
+      final marginValid = Percentage.tryParse(
+        _defaultProfitMarginController.text,
+      );
+      if (marginValid == null) {
+        HMBToast.error('Default Profit Margin is invalid.');
+        return false;
+      }
+
       final system = await DaoSystem().get();
       // Save the form data
       system
@@ -141,6 +149,7 @@ class SystemBillingScreenState extends DeferredState<SystemBillingScreen> {
         ..defaultBookingFee = MoneyEx.tryParse(
           _defaultBookingFeeController.text,
         )
+        ..defaultProfitMargin = marginValid
         ..bsb = _bsbController.text
         ..accountNo = _accountNoController.text
         ..paymentLinkUrl = _paymentLinkUrlController.text
@@ -155,16 +164,6 @@ class SystemBillingScreenState extends DeferredState<SystemBillingScreen> {
         ..billingColour = _billingColour.toColorValue(); // Save billing color
 
       await DaoSystem().update(system);
-      final marginValid = Percentage.tryParse(
-        _defaultProfitMarginController.text,
-      );
-      if (marginValid == null) {
-        HMBToast.error('Default Profit Margin is invalid.');
-        return false;
-      }
-      await AppSettings.setDefaultProfitMarginText(
-        _defaultProfitMarginController.text,
-      );
       await AppSettings.setTaxDisplayMode(_taxDisplayMode);
       await AppSettings.setTaxLabel(_taxLabelController.text);
       await AppSettings.setTaxRatePercentText(_taxRateController.text);
@@ -298,8 +297,9 @@ Sometime this is referred to as a Surcharge, Callout Fee or Admin Fee''',
                   ? 'Enter a valid percentage'
                   : null,
             ).help('Default Profit Margin', '''
-Used as the default margin when creating new Task Items.
-You can still override the margin per Task Item.'''),
+Used as the default margin when creating new Task Items and
+as the starting estimate margin for new Jobs.
+You can still override the margin per Task Item and per Job estimate.'''),
             HMBTextField(
               controller: _bsbController,
               labelText: 'BSB',

--- a/lib/ui/dialog/add_task_item.dart
+++ b/lib/ui/dialog/add_task_item.dart
@@ -17,7 +17,6 @@ import 'package:money2/money2.dart';
 import '../../dao/dao.g.dart';
 import '../../entity/entity.g.dart';
 import '../../entity/helpers/charge_mode.dart';
-import '../../util/dart/app_settings.dart';
 import '../../util/dart/measurement_type.dart';
 import '../../util/dart/money_ex.dart';
 import '../../util/dart/units.dart';
@@ -163,9 +162,7 @@ Future<void> _addTaskItem({
       selectedItemType != null) {
     final quantity = Fixed.tryParse(quantityController.text) ?? Fixed.one;
     final unitCost = MoneyEx.tryParse(unitCostController.text);
-    final defaultMargin =
-        Percentage.tryParse(await AppSettings.getDefaultProfitMarginText()) ??
-        Percentage.zero;
+    final defaultMargin = await DaoSystem().getDefaultProfitMargin();
 
     // Create and insert the new TaskItem
     final newItem = TaskItem.forInsert(

--- a/lib/util/dart/app_settings.dart
+++ b/lib/util/dart/app_settings.dart
@@ -34,7 +34,7 @@ enum TaxDisplayMode {
 class AppSettings {
   static const photoCacheMaxMbDefault = 100;
   static const _photoCacheMaxMbKey = 'photoCacheMaxMb';
-  static const defaultProfitMarginTextDefault = '0';
+  static const defaultProfitMarginTextDefault = '20';
   static const _defaultProfitMarginTextKey = 'defaultProfitMarginText';
   static const _taxDisplayModeKey = 'taxDisplayMode';
   static const _taxLabelKey = 'taxLabel';
@@ -45,8 +45,7 @@ class AppSettings {
   static const _plasterButtJointWeightKey = 'plasterButtJointWeight';
   static const _plasterHighJointWeightKey = 'plasterHighJointWeight';
   static const _plasterSmallPieceWeightKey = 'plasterSmallPieceWeight';
-  static const _plasterFragmentationWeightKey =
-      'plasterFragmentationWeight';
+  static const _plasterFragmentationWeightKey = 'plasterFragmentationWeight';
   static const _plasterVerticalWallPenaltyWeightKey =
       'plasterVerticalWallPenaltyWeight';
 

--- a/test/dao/dao_system_test.dart
+++ b/test/dao/dao_system_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/dao/dao.g.dart';
+import 'package:money2/money2.dart';
+
+import '../database/management/db_utility_test_helper.dart';
+
+void main() {
+  setUp(() async {
+    await setupTestDb();
+  });
+
+  tearDown(() async {
+    await tearDownTestDb();
+  });
+
+  test('system default profit margin persists', () async {
+    final daoSystem = DaoSystem();
+    final system = await daoSystem.get();
+
+    system.defaultProfitMargin = Percentage.fromInt(17500, decimalDigits: 3);
+    await daoSystem.update(system);
+
+    final updated = await daoSystem.get();
+    expect(
+      updated.defaultProfitMargin,
+      Percentage.fromInt(17500, decimalDigits: 3),
+    );
+  });
+
+  test('system default profit margin defaults to 20 percent', () async {
+    final margin = await DaoSystem().getDefaultProfitMargin();
+    expect(margin, Percentage.fromInt(20000, decimalDigits: 3));
+  });
+}


### PR DESCRIPTION
## Summary
- add system-table default profit margin storage with v175 migration
- default the system billing margin to 20% and use it for task items and new job estimates
- persist billing-screen default profit margin changes through DaoSystem

Fixes #419

## Tests
- flutter test test/dao/dao_system_test.dart
- flutter analyze
- git diff --check