### PR TITLE
Fix #418: expand invoice search matching

### DIFF
--- a/lib/dao/dao_invoice.dart
+++ b/lib/dao/dao_invoice.dart
@@ -121,6 +121,7 @@ AND job_id = ?
    OR CAST(i.id AS TEXT) LIKE ?
    OR CAST(j.id AS TEXT) LIKE ?
    OR j.summary LIKE ?
+   OR j.description LIKE ?
    OR c.name LIKE ?
    OR bill.firstName LIKE ?
    OR bill.surname LIKE ?
@@ -128,9 +129,26 @@ AND job_id = ?
    OR jobContact.firstName LIKE ?
    OR jobContact.surname LIKE ?
    OR TRIM(jobContact.firstName || ' ' || jobContact.surname) LIKE ?
+   OR EXISTS (
+        SELECT 1
+        FROM customer_contact cc
+        JOIN contact customerContact ON customerContact.id = cc.contact_id
+        WHERE cc.customer_id = c.id
+          AND (
+               customerContact.firstName LIKE ?
+            OR customerContact.surname LIKE ?
+            OR TRIM(
+                 customerContact.firstName || ' ' || customerContact.surname
+               ) LIKE ?
+          )
+      )
 )
 ''');
       whereArgs.addAll([
+        '%$filter%',
+        '%$filter%',
+        '%$filter%',
+        '%$filter%',
         '%$filter%',
         '%$filter%',
         '%$filter%',

--- a/test/dao/dao_invoice_paid_filter_test.dart
+++ b/test/dao/dao_invoice_paid_filter_test.dart
@@ -347,6 +347,55 @@ void main() {
   );
 
   test(
+    'getByFilter matches job description and secondary customer contact name',
+    () async {
+      final job = await createJobWithCustomer(
+        billingType: BillingType.timeAndMaterial,
+        hourlyRate: MoneyEx.zero,
+        summary: 'Bathroom update',
+      );
+
+      final updatedJob = job.copyWith(description: 'Replace leaking skylight');
+      await DaoJob().update(updatedJob);
+
+      final secondaryContact = Contact.forInsert(
+        firstName: 'Morgan',
+        surname: 'Builder',
+        mobileNumber: '0400111222',
+        landLine: '',
+        officeNumber: '',
+        emailAddress: 'morgan.builder@example.com',
+      );
+      await DaoContact().insert(secondaryContact);
+      final customer = (await DaoCustomer().getById(job.customerId))!;
+      await DaoContactCustomer().insertJoin(secondaryContact, customer);
+
+      final invoice = Invoice.forInsert(
+        jobId: job.id,
+        dueDate: LocalDate.today(),
+        totalAmount: Money.fromInt(1000, isoCode: 'AUD'),
+        billingContactId: job.billingContactId,
+      );
+      await DaoInvoice().insert(invoice);
+      await DaoInvoice().update(
+        invoice.copyWith(invoiceNum: 'INV-DESCRIPTION'),
+      );
+
+      final byDescription = await DaoInvoice().getByFilter('skylight');
+      final bySecondaryContact = await DaoInvoice().getByFilter('morgan');
+
+      expect(
+        byDescription.map((i) => i.invoiceNum),
+        contains('INV-DESCRIPTION'),
+      );
+      expect(
+        bySecondaryContact.map((i) => i.invoiceNum),
+        contains('INV-DESCRIPTION'),
+      );
+    },
+  );
+
+  test(
     'voidInvoice records description and hides invoice by default',
     () async {
       final job = await createJobWithCustomer(


### PR DESCRIPTION
## Summary
- include job descriptions in invoice search matching
- include secondary customer contacts when searching invoices by contact name
- cover both search paths in the invoice DAO tests

Fixes #418

## Tests
- flutter test test/dao/dao_invoice_paid_filter_test.dart
- flutter analyze
- git diff --check