### PR TITLE
Fix #417: expose quote booking fee option

### DIFF
--- a/lib/ui/invoicing/dialog_select_tasks.dart
+++ b/lib/ui/invoicing/dialog_select_tasks.dart
@@ -162,9 +162,14 @@ class _DialogTaskSelectionState extends DeferredState<DialogTaskSelection> {
   Future<void> asyncInitState() async {
     _groupByTask = true;
 
-    billBookingFee = canBillBookingFee =
-        widget.job.billingType == BillingType.timeAndMaterial &&
-        !widget.job.bookingFeeInvoiced;
+    final hasBookingFee =
+        widget.job.bookingFee != null && !widget.job.bookingFee!.isZero;
+    canBillBookingFee = widget.forQuote
+        ? hasBookingFee && !widget.job.bookingFeeInvoiced
+        : widget.job.billingType == BillingType.timeAndMaterial &&
+              hasBookingFee &&
+              !widget.job.bookingFeeInvoiced;
+    billBookingFee = canBillBookingFee;
 
     for (final accuredValue in widget.taskSelectors) {
       _selectedTasks[accuredValue.task.id] = true;

--- a/test/ui/invoicing/dialog_select_tasks_test.dart
+++ b/test/ui/invoicing/dialog_select_tasks_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/dao/dao.g.dart';
+import 'package:hmb/entity/entity.g.dart';
+import 'package:hmb/ui/invoicing/dialog_select_tasks.dart';
+import 'package:money2/money2.dart';
+
+import '../../dao/invoice/utility.dart';
+import '../../database/management/db_utility_test_helper.dart';
+import '../ui_test_helpers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<void> waitForText(
+    WidgetTester tester,
+    String text, {
+    int attempts = 30,
+  }) async {
+    for (var i = 0; i < attempts; i++) {
+      if (find.text(text).evaluate().isNotEmpty) {
+        return;
+      }
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+      });
+      await tester.pump();
+    }
+    throw TestFailure('Timed out waiting for text: $text');
+  }
+
+  setUp(() async {
+    await setupTestDb();
+  });
+
+  tearDown(() async {
+    await tearDownTestDb();
+  });
+
+  testWidgets('fixed price quote can include booking fee', (tester) async {
+    final dialog = await tester.runAsync(() async {
+      final job = await createJobWithCustomer(
+        billingType: BillingType.fixedPrice,
+        hourlyRate: Money.fromInt(5000, isoCode: 'AUD'),
+        bookingFee: Money.fromInt(10000, isoCode: 'AUD'),
+      );
+      final task = await createTask(job, 'Quote task');
+      final contact = await DaoContact().getBillingContactByJob(job);
+
+      return DialogTaskSelection(
+        job: job,
+        contact: contact!,
+        title: 'Tasks to Quote',
+        forQuote: true,
+        taskSelectors: [
+          TaskSelector(task, task.name, Money.fromInt(25000, isoCode: 'AUD')),
+        ],
+      );
+    });
+
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: dialog)));
+    await tester.pumpAndSettle();
+    await waitForText(tester, 'Select All');
+
+    expect(find.text('Bill booking Fee'), findsOneWidget);
+  });
+
+  testWidgets('fixed price invoice does not show booking fee toggle', (
+    tester,
+  ) async {
+    final dialog = await tester.runAsync(() async {
+      final job = await createJobWithCustomer(
+        billingType: BillingType.fixedPrice,
+        hourlyRate: Money.fromInt(5000, isoCode: 'AUD'),
+        bookingFee: Money.fromInt(10000, isoCode: 'AUD'),
+      );
+      final task = await createTask(job, 'Invoice task');
+      final contact = await DaoContact().getBillingContactByJob(job);
+
+      return DialogTaskSelection(
+        job: job,
+        contact: contact!,
+        title: 'Tasks to Invoice',
+        forQuote: false,
+        taskSelectors: [
+          TaskSelector(task, task.name, Money.fromInt(25000, isoCode: 'AUD')),
+        ],
+      );
+    });
+
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: dialog)));
+    await tester.pumpAndSettle();
+    await waitForText(tester, 'Select All');
+
+    expect(find.text('Bill booking Fee'), findsNothing);
+  });
+}


### PR DESCRIPTION
## Summary
- allow the task selection dialog to show the booking-fee toggle for fixed-price quotes
- keep fixed-price invoice selection from showing that toggle
- add widget coverage for both quote and invoice paths

Fixes #417

## Tests
- flutter test test/ui/invoicing/dialog_select_tasks_test.dart
- flutter analyze
- git diff --check