### PR TITLE
Fix #415: copy task photos as images on mobile

### DIFF
--- a/lib/ui/widgets/media/copy_image_to_clipboard.dart
+++ b/lib/ui/widgets/media/copy_image_to_clipboard.dart
@@ -1,0 +1,16 @@
+import 'dart:io';
+
+import 'package:pasteboard/pasteboard.dart';
+
+Future<void> copyImageToClipboard(String imagePath) async {
+  if (Platform.isLinux) {
+    final copied = await Pasteboard.writeFiles([imagePath]);
+    if (!copied) {
+      throw Exception('Failed to copy file reference');
+    }
+    return;
+  }
+
+  final bytes = await File(imagePath).readAsBytes();
+  await Pasteboard.writeImage(bytes);
+}

--- a/lib/ui/widgets/media/full_screen_photo_view.dart
+++ b/lib/ui/widgets/media/full_screen_photo_view.dart
@@ -14,7 +14,6 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:pasteboard/pasteboard.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:strings/strings.dart';
 
@@ -23,6 +22,7 @@ import '../hmb_toast.dart';
 import '../icons/hmb_close_icon.dart';
 import '../icons/hmb_copy_icon.dart';
 import '../layout/layout.g.dart';
+import 'copy_image_to_clipboard.dart';
 
 class FullScreenPhotoViewer extends StatelessWidget {
   final String imagePath;
@@ -88,14 +88,14 @@ class FullScreenPhotoViewer extends StatelessWidget {
               HMBCopyIcon(
                 onPressed: () async {
                   try {
-                    await Pasteboard.writeFiles([imagePath]);
+                    await copyImageToClipboard(imagePath);
                     HMBToast.info('Image copied to clipboard');
                     // ignore: avoid_catches_without_on_clauses
                   } catch (e) {
                     HMBToast.error('Failed to copy image to clipboard');
                   }
                 },
-                hint: 'Copy the photo to the clopboard',
+                hint: 'Copy the photo to the clipboard',
               ),
               HMBCloseIcon(onPressed: () async => Navigator.of(context).pop()),
             ],

--- a/lib/ui/widgets/media/photo_carousel.dart
+++ b/lib/ui/widgets/media/photo_carousel.dart
@@ -17,7 +17,6 @@ import 'dart:io';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:pasteboard/pasteboard.dart';
 import 'package:photo_view/photo_view.dart';
 
 import '../../../util/dart/photo_meta.dart';
@@ -26,6 +25,7 @@ import '../icons/hmb_close_icon.dart';
 import '../icons/hmb_copy_icon.dart';
 import '../layout/layout.g.dart';
 import '../text/hmb_text_themes.dart';
+import 'copy_image_to_clipboard.dart';
 
 class PhotoCarousel extends StatefulWidget {
   final List<PhotoMeta> photos;
@@ -217,9 +217,9 @@ class _PhotoCarouselState extends State<PhotoCarousel> {
       HMBCopyIcon(
         onPressed: () async {
           try {
-            await Pasteboard.writeFiles([
+            await copyImageToClipboard(
               widget.photos[_currentIndex].absolutePathTo,
-            ]);
+            );
             if (context.mounted) {
               ScaffoldMessenger.of(context).showSnackBar(
                 const SnackBar(


### PR DESCRIPTION
## Summary
- add a shared image clipboard helper for media viewers
- copy image bytes on non-Linux platforms so SMS apps can paste the photo data
- keep Linux using file-reference copy behavior

Fixes #415

## Tests
- flutter analyze
- git diff --check