### PR TITLE
Fix #414: refresh quote dashlet count

### DIFF
--- a/lib/ui/crud/job/mini_job_dashboard.dart
+++ b/lib/ui/crud/job/mini_job_dashboard.dart
@@ -117,19 +117,22 @@ class MiniJobDashboard extends StatelessWidget {
               size: dashletSize,
             ),
             _dashlet(
-              child: DashletCard<int>.builder(
-                label: 'Quotes',
-                hint: 'Quote a job based on an Estimate',
-                icon: Icons.format_quote,
-                compact: true,
-                value: () async {
-                  final all = await DaoQuote().getByFilter(null);
-                  final list = all.where((q) => q.jobId == job.id).toList();
-                  return DashletValue<int>(list.length);
-                },
-                builder: (_, _) => HMBFullPageChildScreen(
-                  title: 'Quotes',
-                  child: QuoteListScreen(job: job),
+              child: DaoJuneBuilder.builder(
+                DaoQuote(),
+                builder: (context) => DashletCard<int>.builder(
+                  label: 'Quotes',
+                  hint: 'Quote a job based on an Estimate',
+                  icon: Icons.format_quote,
+                  compact: true,
+                  value: () async {
+                    final all = await DaoQuote().getByFilter(null);
+                    final list = all.where((q) => q.jobId == job.id).toList();
+                    return DashletValue<int>(list.length);
+                  },
+                  builder: (_, _) => HMBFullPageChildScreen(
+                    title: 'Quotes',
+                    child: QuoteListScreen(job: job),
+                  ),
                 ),
               ),
               size: dashletSize,


### PR DESCRIPTION
## Summary
- wrap the job quote dashlet in the quote DAO notifier builder
- let quote insert/update/delete notifications rebuild the dashlet value when returning to the job list

Fixes #414

## Tests
- flutter analyze
- git diff --check