### PR TITLE
Fix #410: separate estimate completion from task status

### DIFF
--- a/assets/sql/upgrade_list.json
+++ b/assets/sql/upgrade_list.json
@@ -1,4 +1,5 @@
 [
+  "assets/sql/upgrade_scripts/v176.sql",
   "assets/sql/upgrade_scripts/v174.sql",
   "assets/sql/upgrade_scripts/v173.sql",
   "assets/sql/upgrade_scripts/v172.sql",

--- a/assets/sql/upgrade_scripts/v176.sql
+++ b/assets/sql/upgrade_scripts/v176.sql
@@ -1,0 +1,2 @@
+ALTER TABLE task
+ADD COLUMN estimate_complete INTEGER NOT NULL DEFAULT 0;

--- a/lib/entity/task.dart
+++ b/lib/entity/task.dart
@@ -30,6 +30,7 @@ class Task extends Entity<Task> {
   BillingType? billingType;
 
   TaskStatus status;
+  bool estimateComplete;
 
   Task._({
     required super.id,
@@ -39,6 +40,7 @@ class Task extends Entity<Task> {
     required this.assumption,
     required this.internalNotes,
     required this.status,
+    required this.estimateComplete,
     required super.createdDate,
     required super.modifiedDate,
     this.billingType,
@@ -49,6 +51,7 @@ class Task extends Entity<Task> {
     required this.name,
     required this.description,
     required this.status,
+    this.estimateComplete = false,
     this.assumption = '',
     this.internalNotes = '',
     this.billingType,
@@ -61,6 +64,7 @@ class Task extends Entity<Task> {
     String? assumption,
     String? internalNotes,
     TaskStatus? status,
+    bool? estimateComplete,
     BillingType? billingType,
   }) => Task._(
     id: id,
@@ -70,6 +74,7 @@ class Task extends Entity<Task> {
     assumption: assumption ?? this.assumption,
     internalNotes: internalNotes ?? this.internalNotes,
     status: status ?? this.status,
+    estimateComplete: estimateComplete ?? this.estimateComplete,
     createdDate: createdDate,
     modifiedDate: DateTime.now(),
     billingType: billingType ?? this.billingType,
@@ -87,6 +92,7 @@ class Task extends Entity<Task> {
     assumption: map['assumption'] as String? ?? '',
     internalNotes: map['internal_notes'] as String? ?? '',
     status: TaskStatus.fromId(map['task_status_id'] as int),
+    estimateComplete: (map['estimate_complete'] as int? ?? 0) == 1,
     createdDate: DateTime.parse(map['createdDate'] as String),
     modifiedDate: DateTime.parse(map['modifiedDate'] as String),
     billingType: (map['billing_type'] as String?) == null
@@ -103,6 +109,7 @@ class Task extends Entity<Task> {
     'assumption': assumption,
     'internal_notes': internalNotes,
     'task_status_id': status.id,
+    'estimate_complete': estimateComplete ? 1 : 0,
     'billing_type': billingType?.name,
     'createdDate': createdDate.toIso8601String(),
     'modifiedDate': modifiedDate.toIso8601String(),
@@ -111,6 +118,7 @@ class Task extends Entity<Task> {
   @override
   String toString() =>
       'Task(id: $id, jobId: $jobId, name: $name, status: ${status.name}, '
-      'assumption: $assumption, internalNotes: $internalNotes, '
+      'estimateComplete: $estimateComplete, assumption: $assumption, '
+      'internalNotes: $internalNotes, '
       'billingType: ${billingType?.name})';
 }

--- a/lib/ui/crud/job/estimator/edit_job_estimate_screen.dart
+++ b/lib/ui/crud/job/estimator/edit_job_estimate_screen.dart
@@ -26,7 +26,6 @@ import '../../../../entity/job.dart';
 import '../../../../entity/task.dart';
 import '../../../../entity/task_item.dart';
 import '../../../../entity/task_item_type.dart';
-import '../../../../entity/task_status.dart';
 import '../../../../util/dart/measurement_type.dart';
 import '../../../../util/dart/money_ex.dart';
 import '../../../../util/dart/units.dart';
@@ -145,8 +144,10 @@ class _JobEstimateBuilderScreenState
         .where(
           (task) =>
               _showActive && task.status.isActive() ||
-              _showCompleted && task.status.isComplete() ||
-              _showToBeEstimated && task.status.toBeEstimated() ||
+              _showCompleted && task.estimateComplete ||
+              _showToBeEstimated &&
+                  !task.estimateComplete &&
+                  !task.status.isWithdrawn() ||
               _showWithdrawn && task.status.isWithdrawn(),
         )
         .toList();
@@ -199,7 +200,7 @@ class _JobEstimateBuilderScreenState
     final estimateTasks = _tasks.where((t) => !t.status.isWithdrawn()).toList();
     _estimateComplete =
         estimateTasks.isNotEmpty &&
-        estimateTasks.every((t) => t.status.isComplete());
+        estimateTasks.every((t) => t.estimateComplete);
   }
 
   Future<void> _addNewTask() async {
@@ -393,7 +394,7 @@ class _JobEstimateBuilderScreenState
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Checkbox(
-                  value: task.status.isComplete(),
+                  value: task.estimateComplete,
                   onChanged: task.status.isWithdrawn()
                       ? null
                       : (checked) async {
@@ -641,10 +642,7 @@ class _JobEstimateBuilderScreenState
 
   Future<void> _setTaskCompletion(Task task, bool isCompleted) async {
     final previousCompleteState = _estimateComplete;
-    final status = isCompleted
-        ? TaskStatus.completed
-        : TaskStatus.awaitingApproval;
-    final updated = task.copyWith(status: status);
+    final updated = task.copyWith(estimateComplete: isCompleted);
     await DaoTask().update(updated);
 
     final index = _tasks.indexWhere((t) => t.id == task.id);
@@ -709,11 +707,11 @@ class _JobEstimateBuilderScreenState
       _buildFilterToggle(
         label: 'Show To Be Estimated',
         hint:
-            '''Show tasks that can be estimated as they have not started no been cancelled''',
+            'Show tasks whose estimate scope and pricing are still in progress',
         helpTitle: 'To Be Estimated',
         helpDetails:
             'Shows tasks that still need estimate work. These are tasks '
-            'that are not completed and not withdrawn.',
+            'that are not estimate-complete and not withdrawn.',
         initialValue: _showToBeEstimated,
         onToggled: (value) {
           _showToBeEstimated = value;
@@ -722,10 +720,10 @@ class _JobEstimateBuilderScreenState
       ),
       _buildFilterToggle(
         label: 'Show Complete',
-        hint: 'Show tasks that have been completed or cancelled',
+        hint: 'Show tasks whose estimate scope and pricing are finalized',
         helpTitle: 'Complete',
         helpDetails:
-            'Shows tasks marked complete. Use this to review tasks where '
+            'Shows tasks marked estimate-complete. Use this to review where '
             'estimate scope and pricing are finalized.',
         initialValue: _showCompleted,
         onToggled: (value) {

--- a/test/dao/dao_task_test.dart
+++ b/test/dao/dao_task_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/dao/dao.g.dart';
+import 'package:hmb/entity/entity.g.dart';
+import 'package:hmb/util/dart/money_ex.dart';
+
+import '../database/management/db_utility_test_helper.dart';
+
+void main() {
+  setUp(() async {
+    await setupTestDb();
+  });
+
+  tearDown(() async {
+    await tearDownTestDb();
+  });
+
+  test(
+    'task estimateComplete defaults to false and persists updates',
+    () async {
+      final customer = Customer.forInsert(
+        name: 'Estimate Customer',
+        description: '',
+        disbarred: false,
+        customerType: CustomerType.residential,
+        hourlyRate: MoneyEx.zero,
+        billingContactId: null,
+      );
+      await DaoCustomer().insert(customer);
+
+      final job = Job.forInsert(
+        customerId: customer.id,
+        summary: 'Estimate Job',
+        description: '',
+        siteId: null,
+        contactId: null,
+        billingContactId: null,
+        status: JobStatus.inProgress,
+        hourlyRate: MoneyEx.zero,
+        bookingFee: MoneyEx.zero,
+      );
+      await DaoJob().insert(job);
+
+      final task = Task.forInsert(
+        jobId: job.id,
+        name: 'Estimate Task',
+        description: '',
+        status: TaskStatus.awaitingApproval,
+      );
+      await DaoTask().insert(task);
+
+      final inserted = (await DaoTask().getById(task.id))!;
+      expect(inserted.estimateComplete, isFalse);
+      expect(inserted.status, TaskStatus.awaitingApproval);
+
+      await DaoTask().update(inserted.copyWith(estimateComplete: true));
+
+      final updated = (await DaoTask().getById(task.id))!;
+      expect(updated.estimateComplete, isTrue);
+      expect(updated.status, TaskStatus.awaitingApproval);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- add a task estimate_complete field and migration so estimate completion is stored separately
- update the estimate builder checkbox, filtering, and overall completion logic to use estimateComplete
- cover DAO persistence for the new estimateComplete field without changing task status

Fixes #410

## Tests
- flutter test test/dao/dao_task_test.dart
- flutter analyze
- git diff --check