### PR TITLE
Fix #422: link receipts to task items

### DIFF
--- a/assets/sql/upgrade_list.json
+++ b/assets/sql/upgrade_list.json
@@ -1,4 +1,5 @@
 [
+  "assets/sql/upgrade_scripts/v175.sql",
   "assets/sql/upgrade_scripts/v174.sql",
   "assets/sql/upgrade_scripts/v173.sql",
   "assets/sql/upgrade_scripts/v172.sql",

--- a/assets/sql/upgrade_scripts/v175.sql
+++ b/assets/sql/upgrade_scripts/v175.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS receipt_task_item (
+  receipt_id INTEGER NOT NULL,
+  task_item_id INTEGER NOT NULL,
+  created_date TEXT NOT NULL DEFAULT (datetime('now')),
+  modified_date TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (receipt_id, task_item_id),
+  FOREIGN KEY (receipt_id) REFERENCES receipt(id),
+  FOREIGN KEY (task_item_id) REFERENCES task_item(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_receipt_task_item_task_item_id
+  ON receipt_task_item(task_item_id);

--- a/lib/dao/dao_receipt.dart
+++ b/lib/dao/dao_receipt.dart
@@ -13,9 +13,11 @@
 
 import '../entity/photo.dart';
 import '../entity/receipt.dart';
+import '../entity/task_item.dart';
 import '../util/dart/exceptions.dart';
 import 'dao.dart';
 import 'dao_photo.dart';
+import 'dao_task_item.dart';
 import 'dao_tool.dart';
 
 class DaoReceipt extends Dao<Receipt> {
@@ -34,12 +36,73 @@ class DaoReceipt extends Dao<Receipt> {
       );
     }
 
+    final linkedTaskItemCount = await countLinkedTaskItems(id);
+    if (linkedTaskItemCount > 0) {
+      throw HMBException(
+        'Cannot delete this receipt while it is linked to task items.',
+      );
+    }
+
     final photos = await DaoPhoto().getByParent(id, ParentType.receipt);
     for (final photo in photos) {
       await DaoPhoto().delete(photo.id, transaction);
     }
 
     return super.delete(id, transaction);
+  }
+
+  Future<int> countLinkedTaskItems(int receiptId) async {
+    final db = withoutTransaction();
+    final rows = await db.rawQuery(
+      '''
+SELECT COUNT(*) AS count
+  FROM receipt_task_item
+ WHERE receipt_id = ?
+''',
+      [receiptId],
+    );
+    return rows.first['count'] as int? ?? 0;
+  }
+
+  Future<List<int>> getLinkedTaskItemIds(int receiptId) async {
+    final db = withoutTransaction();
+    final rows = await db.rawQuery(
+      '''
+SELECT task_item_id
+  FROM receipt_task_item
+ WHERE receipt_id = ?
+ ORDER BY task_item_id
+''',
+      [receiptId],
+    );
+    return rows.map((row) => row['task_item_id']).whereType<int>().toList();
+  }
+
+  Future<List<TaskItem>> getLinkedTaskItems(int receiptId) async {
+    final ids = await getLinkedTaskItemIds(receiptId);
+    return DaoTaskItem().getByIds(ids);
+  }
+
+  Future<void> replaceTaskItemLinks(
+    int receiptId,
+    Iterable<int> taskItemIds,
+  ) async {
+    await db.transaction((txn) async {
+      await txn.delete(
+        'receipt_task_item',
+        where: 'receipt_id = ?',
+        whereArgs: [receiptId],
+      );
+      for (final taskItemId in taskItemIds.toSet()) {
+        final now = DateTime.now().toIso8601String();
+        await txn.insert('receipt_task_item', {
+          'receipt_id': receiptId,
+          'task_item_id': taskItemId,
+          'created_date': now,
+          'modified_date': now,
+        });
+      }
+    });
   }
 
   /// Filter receipts by optional criteria

--- a/lib/dao/dao_task_item.dart
+++ b/lib/dao/dao_task_item.dart
@@ -140,6 +140,33 @@ SELECT ti.*
     return toList(rows);
   }
 
+  Future<List<TaskItem>> getPurchasedItemsForReceiptLink({
+    required int jobId,
+    int? supplierId,
+  }) async {
+    final db = withoutTransaction();
+    final supplierClause = supplierId == null ? '' : 'AND ti.supplier_id = ?';
+    final rows = await db.rawQuery(
+      '''
+SELECT ti.*
+  FROM task_item ti
+  JOIN task t ON ti.task_id = t.id
+ WHERE t.job_id = ?
+   AND ti.item_type_id IN (
+     ${TaskItemType.materialsBuy.id},
+     ${TaskItemType.toolsBuy.id},
+     ${TaskItemType.consumablesBuy.id}
+   )
+   AND ti.completed = 1
+   AND ti.is_return = 0
+   $supplierClause
+ ORDER BY ti.modified_date DESC
+''',
+      [jobId, if (supplierId != null) supplierId],
+    );
+    return toList(rows);
+  }
+
   /// Get items that need to be packed.
   Future<List<TaskItem>> getPackingItems({
     required bool showPreScheduledJobs,
@@ -234,7 +261,7 @@ SELECT ti.*
         .map((id) => "'$id'")
         .join(', ');
 
-  final sql =
+    final sql =
         '''
 SELECT ti.*
   FROM task_item ti

--- a/lib/ui/crud/receipt/edit_receipt_screen.dart
+++ b/lib/ui/crud/receipt/edit_receipt_screen.dart
@@ -12,6 +12,8 @@
 */
 
 // lib/src/ui/receipt/receipt_edit_screen.dart
+import 'dart:async';
+
 import 'package:deferred_state/deferred_state.dart';
 import 'package:flutter/material.dart';
 import 'package:strings/strings.dart';
@@ -53,6 +55,8 @@ class _ReceiptEditScreenState extends DeferredState<ReceiptEditScreen>
   late HMBMoneyEditingController _taxCtrl;
   late HMBMoneyEditingController _totalInclCtrl;
   late PhotoController<Receipt> _photoCtrl;
+  final _linkedTaskItemIds = <int>{};
+  var _linkableTaskItems = <TaskItem>[];
 
   var _isCalculating = false;
 
@@ -110,6 +114,12 @@ class _ReceiptEditScreenState extends DeferredState<ReceiptEditScreen>
       parent: currentEntity,
       parentType: ParentType.receipt,
     );
+    if (currentEntity != null) {
+      _linkedTaskItemIds.addAll(
+        await DaoReceipt().getLinkedTaskItemIds(currentEntity!.id),
+      );
+    }
+    await _reloadLinkableTaskItems();
   }
 
   @override
@@ -139,19 +149,25 @@ class _ReceiptEditScreenState extends DeferredState<ReceiptEditScreen>
       HMBSelectJob(
         selectedJob: _selectedJob,
         required: true,
-        onSelected: (job) => setState(() {
-          _selectedJob.jobId = job?.id;
-        }),
+        onSelected: (job) {
+          setState(() {
+            _selectedJob.jobId = job?.id;
+          });
+          unawaited(_reloadLinkableTaskItems());
+        },
       ),
       // SUPPLIER: now using your SelectSupplier widget
       HMBSelectSupplier(
         selectedSupplier: selectedSupplier,
         required: true,
 
-        onSelected: (supplier) => setState(() {
-          _supplierId = supplier?.id;
-          selectedSupplier.selected = supplier?.id;
-        }),
+        onSelected: (supplier) {
+          setState(() {
+            _supplierId = supplier?.id;
+            selectedSupplier.selected = supplier?.id;
+          });
+          unawaited(_reloadLinkableTaskItems());
+        },
       ),
 
       // MONEY FIELDS: dollars entry
@@ -173,6 +189,7 @@ class _ReceiptEditScreenState extends DeferredState<ReceiptEditScreen>
         fieldName: 'Total Excluding Tax',
         focusNode: _taxExFocus,
       ),
+      _buildTaskItemLinks(),
 
       // Photos
       PhotoCrud<Receipt>(
@@ -210,8 +227,104 @@ class _ReceiptEditScreenState extends DeferredState<ReceiptEditScreen>
       parent: currentEntity,
       parentType: ParentType.receipt,
     );
+    if (currentEntity != null) {
+      await DaoReceipt().replaceTaskItemLinks(
+        currentEntity!.id,
+        _linkedTaskItemIds,
+      );
+    }
     await _photoCtrl.load();
+    await _reloadLinkableTaskItems();
     setState(() {});
+  }
+
+  Widget _buildTaskItemLinks() {
+    final jobId = _selectedJob.jobId;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 8),
+        Text(
+          'Linked task items',
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        Text(
+          'Optional. Select the purchased items this receipt covers.',
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+        if (jobId == null)
+          const Padding(
+            padding: EdgeInsets.only(top: 8),
+            child: Text('Select a job before linking task items.'),
+          )
+        else if (_linkableTaskItems.isEmpty)
+          const Padding(
+            padding: EdgeInsets.only(top: 8),
+            child: Text(
+              'No completed buy items are available for this job and supplier.',
+            ),
+          )
+        else
+          ..._linkableTaskItems.map(
+            (item) => CheckboxListTile(
+              contentPadding: EdgeInsets.zero,
+              title: Text(item.description),
+              subtitle: Text(_formatTaskItemCost(item)),
+              value: _linkedTaskItemIds.contains(item.id),
+              onChanged: (selected) {
+                setState(() {
+                  if (selected ?? false) {
+                    _linkedTaskItemIds.add(item.id);
+                  } else {
+                    _linkedTaskItemIds.remove(item.id);
+                  }
+                });
+              },
+            ),
+          ),
+      ],
+    );
+  }
+
+  Future<void> _reloadLinkableTaskItems() async {
+    final jobId = _selectedJob.jobId;
+    if (jobId == null) {
+      _linkableTaskItems = [];
+      if (mounted) {
+        setState(() {});
+      }
+      return;
+    }
+
+    final candidates = await DaoTaskItem().getPurchasedItemsForReceiptLink(
+      jobId: jobId,
+      supplierId: _supplierId,
+    );
+    final linked = currentEntity == null
+        ? <TaskItem>[]
+        : await DaoReceipt().getLinkedTaskItems(currentEntity!.id);
+    final byId = <int, TaskItem>{
+      for (final item in candidates) item.id: item,
+      for (final item in linked) item.id: item,
+    };
+    _linkableTaskItems = byId.values.toList()
+      ..sort((lhs, rhs) => rhs.modifiedDate.compareTo(lhs.modifiedDate));
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  String _formatTaskItemCost(TaskItem item) {
+    final unitCost =
+        item.actualMaterialUnitCost ?? item.estimatedMaterialUnitCost;
+    final quantity =
+        item.actualMaterialQuantity ?? item.estimatedMaterialQuantity;
+    if (unitCost == null || quantity == null) {
+      return item.itemType.label;
+    }
+
+    final total = unitCost.multiplyByFixed(quantity);
+    return '${item.itemType.label} - $quantity x $unitCost = $total';
   }
 
   void _recalculate() {

--- a/test/dao/dao_task_item_test.dart
+++ b/test/dao/dao_task_item_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hmb/dao/dao.g.dart';
 import 'package:hmb/entity/entity.g.dart';
 import 'package:hmb/entity/helpers/charge_mode.dart';
+import 'package:hmb/util/dart/exceptions.dart';
 import 'package:hmb/util/dart/measurement_type.dart';
 import 'package:hmb/util/dart/money_ex.dart';
 import 'package:hmb/util/dart/units.dart';
@@ -162,6 +163,58 @@ void main() {
     expect(reloaded.userDefinedCharge, Money.fromInt(12345, isoCode: 'AUD'));
     expect(reloaded.completed, isTrue);
   });
+
+  test('receipt can link to multiple task items', () async {
+    final firstItem = await _insertTaskItemForJob(
+      jobStatus: JobStatus.inProgress,
+      taskStatus: TaskStatus.inProgress,
+      itemType: TaskItemType.materialsBuy,
+      completed: true,
+    );
+    final task = (await DaoTask().getById(firstItem.taskId))!;
+    final secondItem = await _insertTaskItemForExistingJob(
+      jobId: task.jobId,
+      itemType: TaskItemType.toolsBuy,
+      completed: true,
+    );
+    final supplier = Supplier.forInsert(
+      name: 'Receipt Supplier',
+      businessNumber: '',
+      description: '',
+      bsb: '',
+      accountNumber: '',
+      service: '',
+    );
+    await DaoSupplier().insert(supplier);
+    final receipt = Receipt.forInsert(
+      receiptDate: DateTime.now(),
+      jobId: task.jobId,
+      supplierId: supplier.id,
+      totalExcludingTax: MoneyEx.fromInt(10000),
+      tax: MoneyEx.fromInt(1000),
+      totalIncludingTax: MoneyEx.fromInt(11000),
+    );
+    await DaoReceipt().insert(receipt);
+
+    await DaoReceipt().replaceTaskItemLinks(receipt.id, [
+      firstItem.id,
+      secondItem.id,
+    ]);
+
+    expect(
+      await DaoReceipt().getLinkedTaskItemIds(receipt.id),
+      equals([firstItem.id, secondItem.id]),
+    );
+    expect(await DaoReceipt().countLinkedTaskItems(receipt.id), 2);
+    expect(() => DaoReceipt().delete(receipt.id), throwsA(isA<HMBException>()));
+
+    await DaoReceipt().replaceTaskItemLinks(receipt.id, [secondItem.id]);
+
+    expect(
+      await DaoReceipt().getLinkedTaskItemIds(receipt.id),
+      equals([secondItem.id]),
+    );
+  });
 }
 
 Future<TaskItem> _insertMaterialTaskItem() => _insertTaskItemForJob(
@@ -212,6 +265,43 @@ Future<TaskItem> _insertTaskItemForJob({
   final item = TaskItem.forInsert(
     taskId: task.id,
     description: 'Paint',
+    purpose: '',
+    itemType: itemType,
+    estimatedMaterialUnitCost: MoneyEx.fromInt(500),
+    estimatedMaterialQuantity: Fixed.one,
+    actualMaterialUnitCost: MoneyEx.fromInt(500),
+    actualMaterialQuantity: Fixed.one,
+    chargeMode: ChargeMode.calculated,
+    margin: Percentage.zero,
+    completed: completed,
+    measurementType: MeasurementType.length,
+    dimension1: Fixed.zero,
+    dimension2: Fixed.zero,
+    dimension3: Fixed.zero,
+    units: Units.m,
+    url: '',
+    labourEntryMode: LabourEntryMode.hours,
+  );
+  await DaoTaskItem().insert(item);
+  return item;
+}
+
+Future<TaskItem> _insertTaskItemForExistingJob({
+  required int jobId,
+  required TaskItemType itemType,
+  required bool completed,
+}) async {
+  final task = Task.forInsert(
+    jobId: jobId,
+    name: 'Task 2',
+    description: '',
+    status: TaskStatus.inProgress,
+  );
+  await DaoTask().insert(task);
+
+  final item = TaskItem.forInsert(
+    taskId: task.id,
+    description: 'Second item',
     purpose: '',
     itemType: itemType,
     estimatedMaterialUnitCost: MoneyEx.fromInt(500),


### PR DESCRIPTION
## Summary
- add a receipt_task_item join table so one receipt can be linked to multiple task items
- add receipt DAO helpers and deletion guard for linked task items
- add optional task item linking inside the receipt editor with item cost context visible beside the receipt totals

Fixes #422

## Tests
- flutter test test/dao/dao_task_item_test.dart
- flutter analyze
- git diff --check