### PR TITLE
Fix #416: allow quote names

### DIFF
--- a/lib/dao/dao_quote.dart
+++ b/lib/dao/dao_quote.dart
@@ -124,9 +124,10 @@ class DaoQuote extends Dao<Quote> {
     final insertedLines = <QuoteLine>[];
 
     // Insert the Quote
+    final quoteName = invoiceOptions.quoteName?.trim();
     final quote = Quote.forInsert(
       jobId: job.id,
-      summary: job.summary,
+      summary: quoteName?.isNotEmpty ?? false ? quoteName! : job.summary,
       description: job.description,
       totalAmount: totalAmount,
       assumption: job.assumption,

--- a/lib/ui/invoicing/dialog_select_tasks.dart
+++ b/lib/ui/invoicing/dialog_select_tasks.dart
@@ -149,6 +149,7 @@ class DialogTaskSelection extends StatefulWidget {
 class _DialogTaskSelectionState extends DeferredState<DialogTaskSelection> {
   final Map<int, bool> _selectedTasks = {};
   final Map<int, BillingType> _taskBillingTypes = {};
+  late final TextEditingController _quoteNameController;
   var _selectAll = true;
   late bool billBookingFee;
   late bool canBillBookingFee;
@@ -157,6 +158,12 @@ class _DialogTaskSelectionState extends DeferredState<DialogTaskSelection> {
   late Customer _customer;
   late Contact _selectedContact;
   List<Contact> _contacts = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _quoteNameController = TextEditingController(text: widget.job.summary);
+  }
 
   @override
   Future<void> asyncInitState() async {
@@ -175,6 +182,12 @@ class _DialogTaskSelectionState extends DeferredState<DialogTaskSelection> {
     _customer = (await DaoCustomer().getById(widget.job.customerId))!;
     _contacts = await DaoContact().getByCustomer(widget.job.customerId);
     _selectedContact = widget.contact;
+  }
+
+  @override
+  void dispose() {
+    _quoteNameController.dispose();
+    super.dispose();
   }
 
   bool get _hasSelectedTimeAndMaterialsTasks => _selectedTasks.entries.any(
@@ -253,6 +266,11 @@ class _DialogTaskSelectionState extends DeferredState<DialogTaskSelection> {
                   });
                 },
               ),
+            if (widget.forQuote)
+              TextField(
+                controller: _quoteNameController,
+                decoration: const InputDecoration(labelText: 'Quote Name'),
+              ),
             if (_selectedTasks.isNotEmpty)
               CheckboxListTile(
                 title: const Text('Select All'),
@@ -297,6 +315,7 @@ class _DialogTaskSelectionState extends DeferredState<DialogTaskSelection> {
               groupByTask: !_hasSelectedTimeAndMaterialsTasks || _groupByTask,
               contact: _selectedContact,
               quoteMargin: widget.job.estimateMargin,
+              quoteName: _quoteNameController.text.trim(),
             ),
           );
         },

--- a/lib/ui/invoicing/invoice_options.dart
+++ b/lib/ui/invoicing/invoice_options.dart
@@ -23,6 +23,7 @@ class InvoiceOptions {
   Contact contact;
   Percentage quoteMargin;
   Map<int, Percentage> taskMargins;
+  String? quoteName;
 
   InvoiceOptions({
     required this.selectedTaskIds,
@@ -31,6 +32,7 @@ class InvoiceOptions {
     required this.contact,
     Percentage? quoteMargin,
     Map<int, Percentage>? taskMargins,
+    this.quoteName,
   }) : quoteMargin = quoteMargin ?? Percentage.zero,
        taskMargins = taskMargins ?? {};
 }

--- a/lib/ui/quoting/list_quote_screen.dart
+++ b/lib/ui/quoting/list_quote_screen.dart
@@ -150,7 +150,7 @@ class _QuoteListScreenState extends State<QuoteListScreen> {
     entityNamePlural: 'Quotes',
     dao: DaoQuote(),
     listCardTitle: (quote) => Text(
-      'Quote #${quote.id} - Issued: ${formatDate(quote.createdDate)}',
+      _quoteListTitle(quote),
       style: const TextStyle(fontWeight: FontWeight.bold),
     ),
     fetchList: _fetchFilteredQuotes,
@@ -174,6 +174,13 @@ class _QuoteListScreenState extends State<QuoteListScreen> {
       _includeRejected = true;
     },
   );
+
+  String _quoteListTitle(Quote quote) {
+    final name = quote.summary.trim();
+    final suffix = name.isEmpty ? '' : ' - $name';
+    final issued = formatDate(quote.createdDate);
+    return 'Quote #${quote.id}$suffix - Issued: $issued';
+  }
 
   Widget _buildQuoteCard(Quote quote) => QuoteCard(
     key: ValueKey(quote.id),

--- a/lib/ui/quoting/quote_card.dart
+++ b/lib/ui/quoting/quote_card.dart
@@ -361,6 +361,7 @@ To approve it, reply to this email with:
                   Text(jc.job.summary),
                 ],
               ),
+              if (quote.summary.trim().isNotEmpty) Text(quote.summary),
               Text('Customer: ${jc.customer.name}'),
               Text('Primary Contact: ${jc.primaryContact?.fullname ?? 'N/A'}'),
               Text('Billing Contact: ${jc.billingContact?.fullname ?? 'N/A'}'),

--- a/lib/ui/quoting/quote_details_screen.dart
+++ b/lib/ui/quoting/quote_details_screen.dart
@@ -77,6 +77,7 @@ class _QuoteDetailsScreenState extends DeferredState<QuoteDetailsScreen> {
           'Quote #${_quote.id}',
           style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
         ),
+        if (_quote.summary.trim().isNotEmpty) Text(_quote.summary),
         Text('Issued: ${formatDate(_quote.createdDate)}'),
         Text('Job ID: ${_quote.jobId}'),
         HMBRow(

--- a/lib/ui/quoting/select_quote_dialog.dart
+++ b/lib/ui/quoting/select_quote_dialog.dart
@@ -75,10 +75,12 @@ class _SelectQuoteDialogState extends State<SelectQuoteDialog> {
     return quotes.where((cj) {
       final customerName = cj.customer.name.toLowerCase();
       final jobSummary = cj.job.summary.toLowerCase();
+      final quoteSummary = cj.quote.summary.toLowerCase();
       final contactName = (cj.contactName ?? '').toLowerCase();
 
       return customerName.contains(_searchQuery) ||
           jobSummary.contains(_searchQuery) ||
+          quoteSummary.contains(_searchQuery) ||
           contactName.contains(_searchQuery);
     }).toList();
   }
@@ -157,11 +159,15 @@ class _SelectQuoteDialogState extends State<SelectQuoteDialog> {
                   itemCount: filteredQuotes.length,
                   itemBuilder: (context, index) {
                     final current = filteredQuotes[index];
+                    final quoteName = current.quote.summary.trim();
                     return ListTile(
-                      title: Text(current.job.summary),
+                      title: Text(
+                        quoteName.isEmpty ? current.job.summary : quoteName,
+                      ),
                       subtitle: HMBColumn(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
+                          Text('Job: ${current.job.summary}'),
                           Text('Customer: ${current.customer.name}'),
                           if (current.contactName != null)
                             Text('Contact: ${current.contactName}'),

--- a/test/dao/dao_quote_charge_mode_test.dart
+++ b/test/dao/dao_quote_charge_mode_test.dart
@@ -111,6 +111,53 @@ void main() {
     },
   );
 
+  test('create uses the supplied quote name', () async {
+    final job = await createJobWithCustomer(
+      billingType: BillingType.fixedPrice,
+      hourlyRate: Money.fromInt(8000, isoCode: 'AUD'),
+    );
+    final task = Task.forInsert(
+      jobId: job.id,
+      name: 'Named quote task',
+      description: '',
+      status: TaskStatus.awaitingApproval,
+    );
+    await DaoTask().insert(task);
+    await DaoTaskItem().insert(
+      TaskItem.forInsert(
+        taskId: task.id,
+        description: 'Labour item',
+        purpose: '',
+        itemType: TaskItemType.labour,
+        estimatedLabourHours: Fixed.one,
+        estimatedLabourCost: Money.fromInt(8000, isoCode: 'AUD'),
+        chargeMode: ChargeMode.calculated,
+        margin: Percentage.zero,
+        measurementType: MeasurementType.length,
+        dimension1: Fixed.zero,
+        dimension2: Fixed.zero,
+        dimension3: Fixed.zero,
+        units: Units.m,
+        url: '',
+        labourEntryMode: LabourEntryMode.hours,
+      ),
+    );
+
+    final contact = (await DaoContact().getById(job.contactId))!;
+    final quote = await DaoQuote().create(
+      job,
+      InvoiceOptions(
+        selectedTaskIds: [task.id],
+        billBookingFee: false,
+        groupByTask: true,
+        contact: contact,
+        quoteName: 'Bathroom extras',
+      ),
+    );
+
+    expect(quote.summary, 'Bathroom extras');
+  });
+
   test('folds task and whole-quote margins into visible quote lines', () async {
     final job = await createJobWithCustomer(
       billingType: BillingType.fixedPrice,


### PR DESCRIPTION
## Summary
- add a quote name field when selecting tasks for a quote
- persist the supplied quote name instead of always using the job summary
- show quote names in quote lists, details, cards, and quote selection search

Fixes #416

## Tests
- flutter test test/dao/dao_quote_charge_mode_test.dart
- flutter analyze
- git diff --check