### PR TITLE
Fix #407: show joint tape in metres

### DIFF
--- a/lib/ui/tools/plasterboard/plaster_project_pdf.dart
+++ b/lib/ui/tools/plasterboard/plaster_project_pdf.dart
@@ -135,7 +135,10 @@ Future<File> generatePlasterProjectPdf({
                 'Outside corners',
                 _pdfLength(takeoff.outsideCornerLength, unitSystem),
               ],
-              ['Tape', _pdfLength(takeoff.tapeLength, unitSystem)],
+              [
+                'Tape',
+                PlasterGeometry.formatJointTapeLength(takeoff.tapeLength),
+              ],
               ['Screws', '${takeoff.screwCount}'],
               ['Stud adhesive', '${takeoff.glueKg.toStringAsFixed(1)} kg'],
               ['Joint compound', '${takeoff.plasterKg.toStringAsFixed(1)} kg'],

--- a/lib/ui/tools/plasterboard/plaster_project_screen.dart
+++ b/lib/ui/tools/plasterboard/plaster_project_screen.dart
@@ -2096,9 +2096,8 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
               child: LayoutBuilder(
                 builder: (context, constraints) {
                   final narrow = constraints.maxWidth < 500;
-                  final estimatedTape = PlasterGeometry.formatDisplayLength(
+                  final estimatedTape = PlasterGeometry.formatJointTapeLength(
                     layout.estimatedJointTapeLength,
-                    _unitSystemForLayout(layout),
                   );
                   final details = Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
@@ -2343,10 +2342,7 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
         ListTile(
           title: const Text('Tape'),
           trailing: Text(
-            PlasterGeometry.formatLinearTakeoffLength(
-              takeoff.tapeLength,
-              unitSystem,
-            ),
+            PlasterGeometry.formatJointTapeLength(takeoff.tapeLength),
           ),
         ),
         ListTile(

--- a/lib/util/dart/plaster_geometry.dart
+++ b/lib/util/dart/plaster_geometry.dart
@@ -877,6 +877,12 @@ class PlasterGeometry {
     return '${feet.toStringAsFixed(2)} ft';
   }
 
+  static String formatJointTapeLength(int value) {
+    const unitsPerMeter = metricUnitsPerMm * 1000;
+    final meters = (value + unitsPerMeter - 1) ~/ unitsPerMeter;
+    return '$meters m';
+  }
+
   static int? parseDisplayLength(String raw, PreferredUnitSystem unitSystem) {
     final value = raw.trim();
     if (value.isEmpty) {

--- a/test/util/plaster_geometry_test.dart
+++ b/test/util/plaster_geometry_test.dart
@@ -84,6 +84,14 @@ void main() {
       );
     });
 
+    test('formats joint tape as whole metres rounded up', () {
+      expect(PlasterGeometry.formatJointTapeLength(0), '0 m');
+      expect(PlasterGeometry.formatJointTapeLength(1), '1 m');
+      expect(PlasterGeometry.formatJointTapeLength(9999), '1 m');
+      expect(PlasterGeometry.formatJointTapeLength(10000), '1 m');
+      expect(PlasterGeometry.formatJointTapeLength(10001), '2 m');
+    });
+
     test('convert room bundle converts room, lines and openings', () {
       final room = PlasterRoom.forInsert(
         projectId: 1,


### PR DESCRIPTION
## Summary
- add a joint tape formatter that always displays whole metres rounded up
- use whole-metre tape display in plasterboard layout cards, takeoff summary, and PDF output
- cover zero, exact metre, and partial metre rounding cases

Fixes #407

## Tests
- flutter test test/util/plaster_geometry_test.dart
- flutter analyze
- git diff --check