### PR TITLE
Fix #406: add plasterboard setting help

### DIFF
--- a/lib/ui/crud/system/plasterboard_layout_settings_screen.dart
+++ b/lib/ui/crud/system/plasterboard_layout_settings_screen.dart
@@ -6,6 +6,7 @@ import '../../../util/dart/app_settings.dart';
 import '../../../util/dart/plaster_layout_scoring.dart';
 import '../../widgets/fields/hmb_text_field.dart';
 import '../../widgets/hmb_toast.dart';
+import '../../widgets/icons/help_button.dart';
 import '../../widgets/layout/layout.g.dart';
 import '../../widgets/save_and_close.dart';
 
@@ -141,48 +142,80 @@ class _PlasterboardLayoutSettingsScreenState
                 labelText: 'Extra sheet weight',
                 keyboardType: TextInputType.number,
                 validator: _validateInt,
+              ).help(
+                'Extra Sheet Weight',
+                '''
+How strongly the optimizer avoids using additional sheets. Increase this when fewer ordered sheets matters more than join placement or offcut quality.''',
               ),
               HMBTextField(
                 controller: _jointLengthController,
                 labelText: 'Joint length weight',
                 keyboardType: TextInputType.number,
                 validator: _validateInt,
+              ).help(
+                'Joint Length Weight',
+                '''
+How strongly the optimizer avoids long sheet joints. Increase this to prefer layouts with less tape and finishing work.''',
               ),
               HMBTextField(
                 controller: _cutPieceController,
                 labelText: 'Cut piece weight',
                 keyboardType: TextInputType.number,
                 validator: _validateInt,
+              ).help(
+                'Cut Piece Weight',
+                '''
+How strongly the optimizer avoids extra cut pieces. Increase this to prefer simpler layouts with more full sheets.''',
               ),
               HMBTextField(
                 controller: _buttJointController,
                 labelText: 'Butt joint weight',
                 keyboardType: TextInputType.number,
                 validator: _validateInt,
+              ).help(
+                'Butt Joint Weight',
+                '''
+How strongly the optimizer avoids butt joints. Increase this when butt joints are more expensive or harder to finish on site.''',
               ),
               HMBTextField(
                 controller: _highJointController,
                 labelText: 'High joint weight',
                 keyboardType: TextInputType.number,
                 validator: _validateInt,
+              ).help(
+                'High Joint Weight',
+                '''
+How strongly the optimizer avoids high wall joints. Increase this to prefer joints that are easier to reach from the floor.''',
               ),
               HMBTextField(
                 controller: _smallPieceController,
                 labelText: 'Small piece weight',
                 keyboardType: TextInputType.number,
                 validator: _validateInt,
+              ).help(
+                'Small Piece Weight',
+                '''
+How strongly the optimizer avoids small edge pieces. Increase this to prefer larger, stronger pieces at sheet edges.''',
               ),
               HMBTextField(
                 controller: _fragmentationController,
                 labelText: 'Fragmentation weight',
                 keyboardType: TextInputType.number,
                 validator: _validateInt,
+              ).help(
+                'Fragmentation Weight',
+                '''
+How strongly the optimizer avoids layouts made from many separate fragments. Increase this to prefer cleaner sheet usage.''',
               ),
               HMBTextField(
                 controller: _verticalWallPenaltyController,
                 labelText: 'Vertical wall penalty weight',
                 keyboardType: TextInputType.number,
                 validator: _validateInt,
+              ).help(
+                'Vertical Wall Penalty Weight',
+                '''
+How strongly the optimizer prefers landscape wall layouts over portrait wall layouts when both are otherwise valid.''',
               ),
             ],
           ),

--- a/lib/ui/tools/plasterboard/plaster_project_screen.dart
+++ b/lib/ui/tools/plasterboard/plaster_project_screen.dart
@@ -24,6 +24,7 @@ import '../../nav/nav.g.dart';
 import '../../widgets/blocking_ui.dart';
 import '../../widgets/color_ex.dart';
 import '../../widgets/hmb_child_crud_card.dart';
+import '../../widgets/icons/help_button.dart';
 import '../../widgets/media/pdf_preview.dart';
 import '../../widgets/select/hmb_select_job.dart';
 import '../../widgets/select/hmb_select_supplier.dart';
@@ -2502,6 +2503,10 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
                         ),
                         keyboardType: TextInputType.number,
                         onSubmitted: (_) => unawaited(_saveProject()),
+                      ).help(
+                        'Waste Allowance',
+                        '''
+Adds extra sheets to the final order quantity. Layout waste is still calculated from the actual sheet cuts; this percentage is a purchasing contingency.''',
                       ),
                       const SizedBox(height: 8),
                       TextField(
@@ -2515,6 +2520,10 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
                           decimal: true,
                         ),
                         onSubmitted: (_) => unawaited(_saveProject()),
+                      ).help(
+                        'Default Wall Stud Spacing',
+                        '''
+Default center-to-center spacing for wall studs. Wall butt joints are placed on stud centerlines unless a wall override is set.''',
                       ),
                       TextField(
                         controller: _wallStudOffsetController,
@@ -2527,6 +2536,10 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
                           decimal: true,
                         ),
                         onSubmitted: (_) => unawaited(_saveProject()),
+                      ).help(
+                        'Default Wall Stud Offset',
+                        '''
+Distance from the start of a wall to the first stud centerline. Use wall overrides when a specific wall starts on a different framing position.''',
                       ),
                       TextField(
                         controller: _wallFixingFaceWidthController,
@@ -2539,6 +2552,10 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
                           decimal: true,
                         ),
                         onSubmitted: (_) => unawaited(_saveProject()),
+                      ).help(
+                        'Default Wall Fixing Face Width',
+                        '''
+Width of the stud face available for fixing. It is stored with the project so framing details are complete for layout rules.''',
                       ),
                       TextField(
                         controller: _ceilingFramingSpacingController,
@@ -2551,6 +2568,10 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
                           decimal: true,
                         ),
                         onSubmitted: (_) => unawaited(_saveProject()),
+                      ).help(
+                        'Default Ceiling Framing Spacing',
+                        '''
+Default center-to-center ceiling framing spacing. Ceiling butt joints are placed on framing centerlines unless a room override is set.''',
                       ),
                       TextField(
                         controller: _ceilingFramingOffsetController,
@@ -2563,6 +2584,10 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
                           decimal: true,
                         ),
                         onSubmitted: (_) => unawaited(_saveProject()),
+                      ).help(
+                        'Default Ceiling Framing Offset',
+                        '''
+Distance from the ceiling origin to the first framing centerline. Use room overrides when a ceiling has different framing alignment.''',
                       ),
                       TextField(
                         controller: _ceilingFixingFaceWidthController,
@@ -2575,6 +2600,10 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
                           decimal: true,
                         ),
                         onSubmitted: (_) => unawaited(_saveProject()),
+                      ).help(
+                        'Default Ceiling Fixing Face Width',
+                        '''
+Width of the ceiling framing face available for fixing. It is saved with the project for complete framing metadata.''',
                       ),
                       const SizedBox(height: 12),
                       HMBChildCrudCard(


### PR DESCRIPTION
## Summary
- add standard help icons to plasterboard project framing and waste settings
- add help icons to plasterboard layout scoring settings
- explain how each setting affects layout or optimizer behavior

Fixes #406

## Tests
- flutter analyze
- git diff --check

UI-only help text change; no focused behavioral test was added.