### PR TITLE
Fix #404: support multi-wall editor selection

### DIFF
--- a/lib/ui/tools/plasterboard/plaster_project_screen.dart
+++ b/lib/ui/tools/plasterboard/plaster_project_screen.dart
@@ -67,6 +67,7 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
   final _selectedJob = SelectedJob();
   final _selectedTask = SelectedTask();
   final _selectedSupplier = SelectedSupplier();
+  final _editorSelectionController = RoomEditorSelectionController();
   final _undo = <_RoomBundle>[];
   final _redo = <_RoomBundle>[];
 
@@ -75,7 +76,7 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
   Task? _task;
   Supplier? _supplier;
   var _selectedRoomIndex = 0;
-  int? _selectedLineIndex;
+  Set<int> _selectedLineIndices = {};
   List<_RoomBundle> _rooms = [];
   List<PlasterMaterialSize> _materials = [];
   List<PlasterSurfaceLayout> _layouts = const [];
@@ -98,7 +99,12 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
   bool get _isRoomEditorOnly => widget.editorOnlyRoomId != null;
 
   @override
-  Future<void> asyncInitState() => _load();
+  Future<void> asyncInitState() {
+    _editorSelectionController.addListener(
+      _handleEditorSelectionControllerChanged,
+    );
+    return _load();
+  }
 
   Future<void> _load() async {
     final initialProject =
@@ -289,6 +295,9 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
     _lineStudSpacingController.dispose();
     _lineStudOffsetController.dispose();
     _lineFixingFaceWidthController.dispose();
+    _editorSelectionController
+      ..removeListener(_handleEditorSelectionControllerChanged)
+      ..dispose();
     super.dispose();
   }
 
@@ -541,28 +550,37 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
             _currentRoom.room.ceilingFixingFaceWidthOverride!,
             roomUnitSystem: _currentRoom.room.unitSystem,
           );
-    final selectedLine = _selectedLineIndex == null
-        ? null
-        : _currentRoom.lines[_selectedLineIndex!];
-    _lineStudSpacingController.text = selectedLine?.studSpacingOverride == null
-        ? ''
-        : _formatLengthEntry(
-            selectedLine!.studSpacingOverride!,
-            roomUnitSystem: _currentRoom.room.unitSystem,
-          );
-    _lineStudOffsetController.text = selectedLine?.studOffsetOverride == null
-        ? ''
-        : _formatLengthEntry(
-            selectedLine!.studOffsetOverride!,
-            roomUnitSystem: _currentRoom.room.unitSystem,
-          );
-    _lineFixingFaceWidthController.text =
-        selectedLine?.fixingFaceWidthOverride == null
-        ? ''
-        : _formatLengthEntry(
-            selectedLine!.fixingFaceWidthOverride!,
-            roomUnitSystem: _currentRoom.room.unitSystem,
-          );
+    final selectedLines = _selectedLines;
+    _lineStudSpacingController.text = _formatCommonOverride(
+      selectedLines.map((line) => line.studSpacingOverride),
+    );
+    _lineStudOffsetController.text = _formatCommonOverride(
+      selectedLines.map((line) => line.studOffsetOverride),
+    );
+    _lineFixingFaceWidthController.text = _formatCommonOverride(
+      selectedLines.map((line) => line.fixingFaceWidthOverride),
+    );
+  }
+
+  List<PlasterRoomLine> get _selectedLines => [
+    for (final index in _selectedLineIndices)
+      if (index >= 0 && index < _currentRoom.lines.length)
+        _currentRoom.lines[index],
+  ];
+
+  String _formatCommonOverride(Iterable<int?> values) {
+    final selected = values.toList();
+    if (selected.isEmpty) {
+      return '';
+    }
+    final first = selected.first;
+    if (selected.any((value) => value != first) || first == null) {
+      return '';
+    }
+    return _formatLengthEntry(
+      first,
+      roomUnitSystem: _currentRoom.room.unitSystem,
+    );
   }
 
   Future<void> _commitRoomName() async {
@@ -715,10 +733,9 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
   }
 
   Future<void> _commitSelectedLineFramingOverrides() async {
-    if (_selectedLineIndex == null || _rooms.isEmpty) {
+    if (_selectedLineIndices.isEmpty || _rooms.isEmpty) {
       return;
     }
-    final currentLine = _currentRoom.lines[_selectedLineIndex!];
     final spacingText = _lineStudSpacingController.text.trim();
     final offsetText = _lineStudOffsetController.text.trim();
     final fixingFaceText = _lineFixingFaceWidthController.text.trim();
@@ -749,17 +766,28 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
       }
       return;
     }
-    if (currentLine.studSpacingOverride == spacing &&
-        currentLine.studOffsetOverride == offset &&
-        currentLine.fixingFaceWidthOverride == fixingFaceWidth) {
+    final lines = List<PlasterRoomLine>.from(_currentRoom.lines);
+    var changed = false;
+    for (final index in _selectedLineIndices) {
+      if (index < 0 || index >= lines.length) {
+        continue;
+      }
+      final currentLine = lines[index];
+      if (currentLine.studSpacingOverride == spacing &&
+          currentLine.studOffsetOverride == offset &&
+          currentLine.fixingFaceWidthOverride == fixingFaceWidth) {
+        continue;
+      }
+      lines[index] = currentLine.copyWith(
+        studSpacingOverride: spacing,
+        studOffsetOverride: offset,
+        fixingFaceWidthOverride: fixingFaceWidth,
+      );
+      changed = true;
+    }
+    if (!changed) {
       return;
     }
-    final lines = List<PlasterRoomLine>.from(_currentRoom.lines);
-    lines[_selectedLineIndex!] = currentLine.copyWith(
-      studSpacingOverride: spacing,
-      studOffsetOverride: offset,
-      fixingFaceWidthOverride: fixingFaceWidth,
-    );
     await _updateCurrentRoom(
       _currentRoom.copyWith(lines: lines),
       trackUndo: false,
@@ -858,7 +886,7 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
             roomCeilingFixingFaceWidthController:
                 _roomCeilingFixingFaceWidthController,
             plasterCeiling: _currentRoom.room.plasterCeiling,
-            hasSelectedWall: _selectedLineIndex != null,
+            hasSelectedWall: _selectedLineIndices.isNotEmpty,
             lineStudSpacingController: _lineStudSpacingController,
             lineStudOffsetController: _lineStudOffsetController,
             lineFixingFaceWidthController: _lineFixingFaceWidthController,
@@ -880,6 +908,24 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
       ),
     );
   }
+
+  void _handleEditorSelectionChanged(RoomEditorSelection selection) {
+    if (_rooms.isEmpty) {
+      return;
+    }
+    final selectedLineIndices = selection.selectedLineIndices;
+    if (_selectedLineIndices.length == selectedLineIndices.length &&
+        _selectedLineIndices.containsAll(selectedLineIndices)) {
+      return;
+    }
+    setState(() {
+      _selectedLineIndices = Set<int>.from(selectedLineIndices);
+      _syncRoomControllers();
+    });
+  }
+
+  void _handleEditorSelectionControllerChanged() =>
+      _handleEditorSelectionChanged(_editorSelectionController.value);
 
   Future<List<PlasterMaterialSize>> _loadMaterialsForSupplier(
     int? supplierId,
@@ -1960,6 +2006,7 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
         document: _toEditorDocument(_currentRoom),
         landscape: isMobileLandscape,
         editorOnly: true,
+        selectionController: _editorSelectionController,
         onUndo: _undo.isEmpty ? null : () => unawaited(_undoRoomEdit()),
         onRedo: _redo.isEmpty ? null : () => unawaited(_redoRoomEdit()),
         onDocumentCommitted: (document) async {
@@ -1987,6 +2034,8 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
       ceilingHeightController: _ceilingHeightController,
       lineStudSpacingController: _lineStudSpacingController,
       lineStudOffsetController: _lineStudOffsetController,
+      selectionController: _editorSelectionController,
+      onSelectionChanged: _handleEditorSelectionChanged,
       onUnitChanged: (value) async {
         if (value == null) {
           return;
@@ -2030,6 +2079,7 @@ class _PlasterProjectScreenState extends DeferredState<PlasterProjectScreen>
       return RoomEditorWorkspace(
         document: _toEditorDocument(_currentRoom),
         landscape: true,
+        selectionController: _editorSelectionController,
         onDocumentCommitted: (document) async {
           await _updateCurrentRoom(
             _fromEditorDocument(document, _currentRoom),

--- a/packages/room_editor/lib/src/room_editor_forms.dart
+++ b/packages/room_editor/lib/src/room_editor_forms.dart
@@ -10,7 +10,8 @@ class RoomEditorDetailsForm extends StatelessWidget {
   final String unitLabel;
   final TextEditingController roomNameController;
   final TextEditingController ceilingHeightController;
-  final int? selectedLineId;
+  final int selectedLineCount;
+  final int? selectedLineKey;
   final TextEditingController? lineStudSpacingController;
   final TextEditingController? lineStudOffsetController;
   final ValueChanged<RoomEditorUnitSystem?> onUnitChanged;
@@ -32,7 +33,8 @@ class RoomEditorDetailsForm extends StatelessWidget {
     required this.editorTools,
     required this.canvas,
     super.key,
-    this.selectedLineId,
+    this.selectedLineCount = 0,
+    this.selectedLineKey,
     this.lineStudSpacingController,
     this.lineStudOffsetController,
     this.onCommitSelectedLineOverrides,
@@ -126,18 +128,20 @@ class RoomEditorDetailsForm extends StatelessWidget {
             onEditingComplete: () => unawaited(onCommitCeilingHeight()),
             onTapOutside: (_) => unawaited(onCommitCeilingHeight()),
           ),
-          if (selectedLineId != null &&
+          if (selectedLineCount > 0 &&
               lineStudSpacingController != null &&
               lineStudOffsetController != null &&
               onCommitSelectedLineOverrides != null) ...[
             const SizedBox(height: 8),
             TextField(
               key: ValueKey(
-                'line-stud-spacing-$selectedLineId-${unitSystem.name}',
+                'line-stud-spacing-$selectedLineKey-${unitSystem.name}',
               ),
               controller: lineStudSpacingController,
               decoration: InputDecoration(
-                labelText: 'Wall Stud Spacing Override ($unitLabel)',
+                labelText: selectedLineCount == 1
+                    ? 'Wall Stud Spacing Override ($unitLabel)'
+                    : 'Selected Walls Stud Spacing Override ($unitLabel)',
                 helperText: 'Leave blank to use project default.',
               ),
               keyboardType: const TextInputType.numberWithOptions(
@@ -151,11 +155,13 @@ class RoomEditorDetailsForm extends StatelessWidget {
             const SizedBox(height: 8),
             TextField(
               key: ValueKey(
-                'line-stud-offset-$selectedLineId-${unitSystem.name}',
+                'line-stud-offset-$selectedLineKey-${unitSystem.name}',
               ),
               controller: lineStudOffsetController,
               decoration: InputDecoration(
-                labelText: 'Wall Stud Offset Override ($unitLabel)',
+                labelText: selectedLineCount == 1
+                    ? 'Wall Stud Offset Override ($unitLabel)'
+                    : 'Selected Walls Stud Offset Override ($unitLabel)',
                 helperText: 'Leave blank to use project default.',
               ),
               keyboardType: const TextInputType.numberWithOptions(

--- a/packages/room_editor/lib/src/room_editor_panel.dart
+++ b/packages/room_editor/lib/src/room_editor_panel.dart
@@ -23,10 +23,11 @@ class RoomEditorPanel extends StatefulWidget {
   final ValueChanged<RoomEditorCommand>? onCommand;
   final VoidCallback? onUndo;
   final VoidCallback? onRedo;
+  final ValueChanged<RoomEditorSelection>? onSelectionChanged;
+  final RoomEditorSelectionController? selectionController;
   final List<RoomEditorCustomTool> customTools;
   final Map<int, RoomEditorLinePresentation> linePresentations;
-  final Map<int, RoomEditorIntersectionPresentation>
-  intersectionPresentations;
+  final Map<int, RoomEditorIntersectionPresentation> intersectionPresentations;
 
   const RoomEditorPanel({
     required this.roomId,
@@ -47,6 +48,8 @@ class RoomEditorPanel extends StatefulWidget {
     this.onCommand,
     this.onUndo,
     this.onRedo,
+    this.onSelectionChanged,
+    this.selectionController,
     this.landscape = false,
     this.customTools = const [],
     this.linePresentations = const {},
@@ -63,13 +66,26 @@ class _RoomEditorPanelState extends State<RoomEditorPanel> {
   @override
   void initState() {
     super.initState();
-    _selectionController = RoomEditorSelectionController();
+    _selectionController =
+        widget.selectionController ?? RoomEditorSelectionController();
+    _selectionController.addListener(_notifySelectionChanged);
   }
 
   @override
   void dispose() {
-    _selectionController.dispose();
+    _selectionController.removeListener(_notifySelectionChanged);
+    if (widget.selectionController == null) {
+      _selectionController.dispose();
+    }
     super.dispose();
+  }
+
+  void _notifySelectionChanged() =>
+      widget.onSelectionChanged?.call(_selectionController.value);
+
+  int? _selectionKey(RoomEditorSelection selection) {
+    final selected = selection.selectedLineIndices.toList()..sort();
+    return selected.isEmpty ? null : Object.hashAll(selected);
   }
 
   @override
@@ -82,9 +98,8 @@ class _RoomEditorPanelState extends State<RoomEditorPanel> {
           unitLabel: widget.unitLabel,
           roomNameController: widget.roomNameController,
           ceilingHeightController: widget.ceilingHeightController,
-          selectedLineId: selection.selectedLineIndex == null
-              ? null
-              : widget.document.bundle.lines[selection.selectedLineIndex!].id,
+          selectedLineCount: selection.selectedLineIndices.length,
+          selectedLineKey: _selectionKey(selection),
           lineStudSpacingController: widget.lineStudSpacingController,
           lineStudOffsetController: widget.lineStudOffsetController,
           onUnitChanged: widget.onUnitChanged,


### PR DESCRIPTION
## Summary
- keep the plasterboard screen in sync with room editor multi-line selection
- allow selected wall framing overrides to apply across all selected walls
- update room editor panel labels and selection plumbing for one-or-more selected walls

Fixes #404

## Tests
- flutter test packages/room_editor/test
- flutter test test/util/plaster_geometry_test.dart
- flutter analyze
- git diff --check

Note: dart test packages/room_editor/test was attempted first, but that package imports Flutter and must be run with flutter test.