### PR TITLE
Show open and completed task counts

### DIFF
--- a/lib/ui/crud/job/mini_job_dashboard.dart
+++ b/lib/ui/crud/job/mini_job_dashboard.dart
@@ -18,6 +18,7 @@ import '../../../dao/dao.g.dart';
 import '../../../dao/notification/dao_june_builder.dart';
 import '../../../entity/job.dart';
 import '../../../entity/quote.dart';
+import '../../../entity/task.dart';
 import '../../invoicing/list_invoice_screen.dart';
 import '../../nav/dashboards/dashlet_card.dart';
 import '../../quoting/list_quote_screen.dart';
@@ -72,14 +73,14 @@ class MiniJobDashboard extends StatelessWidget {
               size: dashletSize,
             ),
             _dashlet(
-              child: DashletCard<int>.builder(
+              child: DashletCard<String>.builder(
                 label: 'Tasks',
                 hint: 'Task to be completed for this Job',
                 icon: Icons.task,
                 compact: true,
                 value: () async {
                   final all = await DaoTask().getTasksByJob(job.id);
-                  return DashletValue<int>(all.length);
+                  return taskDashletValue(all);
                 },
                 builder: (_, _) => HMBFullPageChildScreen(
                   title: 'Tasks',
@@ -340,4 +341,10 @@ class MiniJobDashboard extends StatelessWidget {
       ),
     );
   }
+}
+
+DashletValue<String> taskDashletValue(List<Task> tasks) {
+  final open = tasks.where((task) => !task.status.isInActive()).length;
+  final completed = tasks.where((task) => task.status.isComplete()).length;
+  return DashletValue<String>('$open/$completed');
 }

--- a/test/ui/crud/job/mini_job_dashboard_test.dart
+++ b/test/ui/crud/job/mini_job_dashboard_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/entity/entity.g.dart';
+import 'package:hmb/ui/crud/job/mini_job_dashboard.dart';
+
+void main() {
+  test('task dashlet value shows open and completed counts', () {
+    final value = taskDashletValue([
+      _task(TaskStatus.awaitingApproval),
+      _task(TaskStatus.inProgress),
+      _task(TaskStatus.completed),
+      _task(TaskStatus.onHold),
+      _task(TaskStatus.cancelled),
+    ]);
+
+    expect(value.value, '2/1');
+  });
+}
+
+Task _task(TaskStatus status) => Task.forInsert(
+  jobId: 1,
+  name: status.name,
+  description: '',
+  status: status,
+);


### PR DESCRIPTION
Fixes #396.

## Summary
- change the job Tasks dashlet from total tasks to open/completed counts
- count open tasks using the same active/inactive task status split as the task list
- add a focused test for the dashlet count formatter

## Verification
- flutter test test/ui/crud/job/mini_job_dashboard_test.dart
- flutter analyze
- git diff --check