### PR TITLE
Reduce plasterboard joint compound estimate

### DIFF
--- a/lib/util/dart/plaster_geometry.dart
+++ b/lib/util/dart/plaster_geometry.dart
@@ -1336,7 +1336,7 @@ class PlasterGeometry {
               isCeiling: isCeiling,
             ),
             estimatedGlueKg: _estimateGlueKg(area, isCeiling),
-            estimatedPlasterKg: _estimatePlasterKg(area, candidate.$1),
+            estimatedPlasterKg: _estimatePlasterKg(area),
           );
           candidates.add(surface);
           _logSurfaceCandidateDecision(
@@ -2845,10 +2845,10 @@ class PlasterGeometry {
     return areaSqM * 3.5 / 100;
   }
 
-  static double _estimatePlasterKg(int area, PlasterSheetDirection direction) {
+  static double _estimatePlasterKg(int area) {
     final areaSqM = area / (metricUnitsPerMm * metricUnitsPerMm) / 1000000;
-    final multiplier = direction == PlasterSheetDirection.vertical ? 1.2 : 1.0;
-    return areaSqM * (24 + 8) * multiplier / 100;
+    const kgPerHundredSquareMeters = 22.0;
+    return areaSqM * kgPerHundredSquareMeters / 100;
   }
 
   static PlasterTakeoffSummary calculateTakeoff(

--- a/test/util/plaster_geometry_test.dart
+++ b/test/util/plaster_geometry_test.dart
@@ -808,6 +808,10 @@ void main() {
       );
       expect(takeoff.estimatedWasteArea, greaterThanOrEqualTo(0));
       expect(takeoff.estimatedWastePercent, greaterThanOrEqualTo(0));
+      expect(
+        takeoff.plasterKg,
+        closeTo(takeoff.surfaceArea / 100000000 * 22 / 100, 0.001),
+      );
     });
 
     test('project takeoff does not exceed summed raw layout sheets', () {


### PR DESCRIPTION
Fixes #382.

## Summary
- reduce joint compound estimate from 32 kg / 100 m² plus orientation multiplier to 22 kg / 100 m²
- remove the vertical orientation multiplier so sheet direction does not inflate compound quantities
- cover the takeoff rate in the plaster geometry test

## Verification
- flutter test test/util/plaster_geometry_test.dart
- flutter analyze
- git diff --check