### PR TITLE
Show opening dimensions while dragging

### DIFF
--- a/packages/room_editor/lib/src/room_canvas.dart
+++ b/packages/room_editor/lib/src/room_canvas.dart
@@ -838,6 +838,7 @@ class _RoomEditorCanvasState extends State<RoomEditorCanvas> {
                     selectedIntersectionIndices:
                         widget.selection.selectedIntersectionIndices,
                     selectedOpeningIndex: widget.selection.selectedOpeningIndex,
+                    draggedOpeningIndex: _dragOpeningIndex,
                     selectedOpeningDimensionKey:
                         widget.selection.selectedOpeningDimensionKey,
                   ),
@@ -865,6 +866,7 @@ class _RoomPainter extends CustomPainter {
   final Set<int> selectedLineIndices;
   final Set<int> selectedIntersectionIndices;
   final int? selectedOpeningIndex;
+  final int? draggedOpeningIndex;
   final RoomEditorOpeningDimensionKey? selectedOpeningDimensionKey;
 
   RoomEditorBundle get bundle => document.bundle;
@@ -883,6 +885,7 @@ class _RoomPainter extends CustomPainter {
     required this.selectedLineIndices,
     required this.selectedIntersectionIndices,
     required this.selectedOpeningIndex,
+    required this.draggedOpeningIndex,
     required this.selectedOpeningDimensionKey,
   });
 
@@ -1121,7 +1124,7 @@ class _RoomPainter extends CustomPainter {
     final openingDimensionVisuals = buildOpeningDimensionVisuals(
       document: document,
       selection: RoomEditorSelection(
-        selectedOpeningIndex: selectedOpeningIndex,
+        selectedOpeningIndex: draggedOpeningIndex ?? selectedOpeningIndex,
         selectedOpeningDimensionKey: selectedOpeningDimensionKey,
       ),
       transform: transform,
@@ -1379,6 +1382,7 @@ class _RoomPainter extends CustomPainter {
         intersectionPresentations,
       ) ||
       oldDelegate.selectedOpeningIndex != selectedOpeningIndex ||
+      oldDelegate.draggedOpeningIndex != draggedOpeningIndex ||
       oldDelegate.selectedOpeningDimensionKey != selectedOpeningDimensionKey;
 }
 
@@ -1407,6 +1411,20 @@ class RoomEditorConstraintVisualDebug {
     this.label,
     this.constrained = true,
     this.selected = false,
+  });
+}
+
+class RoomEditorOpeningDimensionVisualDebug {
+  final RoomEditorOpeningDimensionKey key;
+  final String label;
+  final bool selected;
+  final Rect hitBox;
+
+  const RoomEditorOpeningDimensionVisualDebug({
+    required this.key,
+    required this.label,
+    required this.selected,
+    required this.hitBox,
   });
 }
 
@@ -2154,6 +2172,42 @@ List<_OpeningDimensionVisual> buildOpeningDimensionVisuals({
     );
   }
   return visuals;
+}
+
+List<RoomEditorOpeningDimensionVisualDebug>
+debugDescribeOpeningDimensionVisuals({
+  required RoomEditorDocument document,
+  int? selectedOpeningIndex,
+  int? draggedOpeningIndex,
+  RoomEditorOpeningDimensionKey? selectedOpeningDimensionKey,
+  Size size = const Size(800, 600),
+}) {
+  final lines = document.bundle.lines;
+  if (lines.isEmpty) {
+    return const [];
+  }
+  final transform = _CanvasTransform(
+    lines,
+    size,
+    bounds: _CanvasWorldBounds.fromLines(lines),
+  );
+  final visuals = buildOpeningDimensionVisuals(
+    document: document,
+    selection: RoomEditorSelection(
+      selectedOpeningIndex: draggedOpeningIndex ?? selectedOpeningIndex,
+      selectedOpeningDimensionKey: selectedOpeningDimensionKey,
+    ),
+    transform: transform,
+  );
+  return [
+    for (final visual in visuals)
+      RoomEditorOpeningDimensionVisualDebug(
+        key: visual.key,
+        label: visual.label,
+        selected: visual.selected,
+        hitBox: visual.hitBox,
+      ),
+  ];
 }
 
 List<RoomEditorConstraintVisualDebug> debugDescribeConstraintVisuals({

--- a/packages/room_editor/test/room_editor_constraint_overlay_test.dart
+++ b/packages/room_editor/test/room_editor_constraint_overlay_test.dart
@@ -3,6 +3,60 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:room_editor/room_editor.dart';
 
 void main() {
+  test('dragged opening shows adjacent wall distance labels', () {
+    final document = RoomEditorDocument(
+      bundle: buildRoomEditorBundle(
+        roomName: 'Openings',
+        unitSystem: RoomEditorUnitSystem.metric,
+        plasterCeiling: true,
+        lines: const [
+          (id: 1, seqNo: 1, startX: 0, startY: 0, length: 3600),
+          (id: 2, seqNo: 2, startX: 3600, startY: 0, length: 2400),
+          (id: 3, seqNo: 3, startX: 3600, startY: 2400, length: 3600),
+          (id: 4, seqNo: 4, startX: 0, startY: 2400, length: 2400),
+        ],
+        openings: const [
+          (
+            id: 10,
+            lineId: 1,
+            type: RoomEditorOpeningType.door,
+            offsetFromStart: 500,
+            width: 800,
+            height: 2100,
+            sillHeight: 0,
+            distanceToStartWall: null,
+            distanceToEndWall: null,
+          ),
+          (
+            id: 20,
+            lineId: 1,
+            type: RoomEditorOpeningType.window,
+            offsetFromStart: 1800,
+            width: 900,
+            height: 1200,
+            sillHeight: 900,
+            distanceToStartWall: null,
+            distanceToEndWall: null,
+          ),
+        ],
+      ),
+      constraints: const [],
+    );
+
+    final visuals = debugDescribeOpeningDimensionVisuals(
+      document: document,
+      selectedOpeningIndex: 0,
+      draggedOpeningIndex: 1,
+    );
+
+    expect(visuals, hasLength(3));
+    expect(visuals.map((visual) => visual.key.openingId), everyElement(20));
+    expect(
+      visuals.map((visual) => visual.key.type),
+      containsAll(RoomEditorOpeningDimensionType.values),
+    );
+  });
+
   test('selected line exposes visible constraint overlays', () {
     final visuals = debugDescribeConstraintVisuals(
       document: _document,


### PR DESCRIPTION
Fixes #378.

## Summary
- use the opening currently being dragged as the active opening for dimension overlays
- keep selected-opening dimension behavior unchanged when no opening drag is active
- add a regression test for dragging an unselected opening

## Verification
- flutter test packages/room_editor/test/room_editor_constraint_overlay_test.dart
- flutter analyze
- git diff --check