### PR TITLE
Scale plaster screw estimates by framing spacing

### DIFF
--- a/lib/util/dart/plaster_geometry.dart
+++ b/lib/util/dart/plaster_geometry.dart
@@ -1334,6 +1334,7 @@ class PlasterGeometry {
               area: area,
               direction: candidate.$1,
               isCeiling: isCeiling,
+              framingSpacing: framingSpacing,
             ),
             estimatedGlueKg: _estimateGlueKg(area, isCeiling),
             estimatedPlasterKg: _estimatePlasterKg(area, candidate.$1),
@@ -2827,6 +2828,7 @@ class PlasterGeometry {
     required int area,
     required PlasterSheetDirection direction,
     required bool isCeiling,
+    required int framingSpacing,
   }) {
     final areaSqM = area / (metricUnitsPerMm * metricUnitsPerMm) / 1000000;
     final perHundredSqM = isCeiling
@@ -2834,7 +2836,11 @@ class PlasterGeometry {
               ? 1150
               : 820
         : 620;
-    return max(1, (areaSqM * perHundredSqM / 100).ceil());
+    final standardSpacing = isCeiling ? 4500 : 6000;
+    final spacingFactor = framingSpacing <= 0
+        ? 1.0
+        : standardSpacing / framingSpacing;
+    return max(1, (areaSqM * perHundredSqM * spacingFactor / 100).ceil());
   }
 
   static double _estimateGlueKg(int area, bool isCeiling) {

--- a/test/util/plaster_geometry_test.dart
+++ b/test/util/plaster_geometry_test.dart
@@ -810,6 +810,140 @@ void main() {
       expect(takeoff.estimatedWastePercent, greaterThanOrEqualTo(0));
     });
 
+    test('wall screw estimate increases with tighter stud spacing', () {
+      final looseProject = PlasterProject.forInsert(
+        name: 'Loose studs',
+        jobId: 1,
+        wastePercent: 15,
+      );
+      final tightProject = PlasterProject.forInsert(
+        name: 'Tight studs',
+        jobId: 1,
+        wastePercent: 15,
+        wallStudSpacing: 3000,
+      );
+      final room = PlasterRoom.forInsert(
+        projectId: 1,
+        name: 'Room 1',
+        unitSystem: PreferredUnitSystem.metric,
+        ceilingHeight: 24000,
+        plasterCeiling: false,
+      );
+      final lines = PlasterGeometry.defaultLines(
+        roomId: 1,
+        unitSystem: PreferredUnitSystem.metric,
+      );
+      final materials = [
+        PlasterMaterialSize.forInsert(
+          supplierId: 1,
+          name: '1200 x 2400',
+          unitSystem: PreferredUnitSystem.metric,
+          width: 12000,
+          height: 24000,
+        ),
+      ];
+
+      final looseShape = PlasterRoomShape(
+        project: looseProject,
+        room: room,
+        lines: lines,
+        openings: const [],
+      );
+      final tightShape = PlasterRoomShape(
+        project: tightProject,
+        room: room,
+        lines: lines,
+        openings: const [],
+      );
+
+      final looseLayouts = PlasterGeometry.calculateLayout([
+        looseShape,
+      ], materials);
+      final tightLayouts = PlasterGeometry.calculateLayout([
+        tightShape,
+      ], materials);
+      final looseTakeoff = PlasterGeometry.calculateTakeoff(
+        [looseShape],
+        looseLayouts,
+        15,
+      );
+      final tightTakeoff = PlasterGeometry.calculateTakeoff(
+        [tightShape],
+        tightLayouts,
+        15,
+      );
+
+      expect(tightTakeoff.screwCount, greaterThan(looseTakeoff.screwCount));
+    });
+
+    test('ceiling screw estimate increases with tighter framing spacing', () {
+      final looseProject = PlasterProject.forInsert(
+        name: 'Loose ceiling',
+        jobId: 1,
+        wastePercent: 15,
+      );
+      final tightProject = PlasterProject.forInsert(
+        name: 'Tight ceiling',
+        jobId: 1,
+        wastePercent: 15,
+        ceilingFramingSpacing: 3000,
+      );
+      final room = PlasterRoom.forInsert(
+        projectId: 1,
+        name: 'Room 1',
+        unitSystem: PreferredUnitSystem.metric,
+        ceilingHeight: 24000,
+      );
+      final lines = [
+        for (final line in PlasterGeometry.defaultLines(
+          roomId: 1,
+          unitSystem: PreferredUnitSystem.metric,
+        ))
+          line.copyWith(plasterSelected: false),
+      ];
+      final materials = [
+        PlasterMaterialSize.forInsert(
+          supplierId: 1,
+          name: '1200 x 2400',
+          unitSystem: PreferredUnitSystem.metric,
+          width: 12000,
+          height: 24000,
+        ),
+      ];
+
+      final looseShape = PlasterRoomShape(
+        project: looseProject,
+        room: room,
+        lines: lines,
+        openings: const [],
+      );
+      final tightShape = PlasterRoomShape(
+        project: tightProject,
+        room: room,
+        lines: lines,
+        openings: const [],
+      );
+
+      final looseLayouts = PlasterGeometry.calculateLayout([
+        looseShape,
+      ], materials);
+      final tightLayouts = PlasterGeometry.calculateLayout([
+        tightShape,
+      ], materials);
+      final looseTakeoff = PlasterGeometry.calculateTakeoff(
+        [looseShape],
+        looseLayouts,
+        15,
+      );
+      final tightTakeoff = PlasterGeometry.calculateTakeoff(
+        [tightShape],
+        tightLayouts,
+        15,
+      );
+
+      expect(tightTakeoff.screwCount, greaterThan(looseTakeoff.screwCount));
+    });
+
     test('project takeoff does not exceed summed raw layout sheets', () {
       final room1 = PlasterRoom.forInsert(
         projectId: 1,


### PR DESCRIPTION
Fixes #372.

## Summary
- pass wall/ceiling framing spacing into the screw estimate
- scale screw quantities against the existing default wall and ceiling framing spacings
- add wall and ceiling tests proving tighter spacing increases screw counts

## Verification
- flutter test test/util/plaster_geometry_test.dart
- flutter analyze
- git diff --check