### PR TITLE
Simplify CRUD save actions

### DIFF
--- a/lib/ui/widgets/save_and_close.dart
+++ b/lib/ui/widgets/save_and_close.dart
@@ -24,9 +24,8 @@ class SaveAndClose extends StatelessWidget {
   final AsyncVoidCallback onCancel;
   final bool showSaveOnly;
 
-  /// The [showSaveOnly] argument controls whether the 'Save' button
-  /// will be displayed. We normally only display the save button
-  /// during the insert phase of a CRUD.
+  /// The [showSaveOnly] argument indicates that the first save should keep
+  /// the editor open so child records can be added.
   const SaveAndClose({
     required this.onSave,
     required this.showSaveOnly,
@@ -40,17 +39,12 @@ class SaveAndClose extends StatelessWidget {
     child: Row(
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        if (showSaveOnly)
-          HMBButton(
-            onPressed: () => unawaited(onSave(close: false)),
-            label: 'Save',
-            hint: "Save your changes but don't close the window",
-          ),
-        const HMBSpacer(width: true),
         HMBButton(
-          label: 'Save & Close',
-          hint: 'Save your changes and close this window',
-          onPressed: () => unawaited(onSave(close: true)),
+          label: 'Save',
+          hint: showSaveOnly
+              ? 'Save your changes so child records can be added'
+              : 'Save your changes',
+          onPressed: () => unawaited(onSave(close: !showSaveOnly)),
         ),
         const HMBSpacer(width: true),
         HMBButton(

--- a/test/ui/widgets/save_and_close_test.dart
+++ b/test/ui/widgets/save_and_close_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/ui/widgets/save_and_close.dart';
+
+void main() {
+  testWidgets('new entities save without closing', (tester) async {
+    bool? closeValue;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SaveAndClose(
+            showSaveOnly: true,
+            onSave: ({required close}) async => closeValue = close,
+            onCancel: () async {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Save'), findsOneWidget);
+    expect(find.text('Save & Close'), findsNothing);
+
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+
+    expect(closeValue, isFalse);
+  });
+
+  testWidgets('existing entities save and close', (tester) async {
+    bool? closeValue;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SaveAndClose(
+            showSaveOnly: false,
+            onSave: ({required close}) async => closeValue = close,
+            onCancel: () async {},
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Save'), findsOneWidget);
+    expect(find.text('Save & Close'), findsNothing);
+
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+
+    expect(closeValue, isTrue);
+  });
+}


### PR DESCRIPTION
Fixes #360.

## Summary
- replace the shared Save & Close footer action with a single Save action plus Cancel
- keep new CRUD records open after the first save so child records can be added
- save and close for already-persisted records

## Verification
- flutter test test/ui/widgets/save_and_close_test.dart
- flutter analyze
- git diff --check

## Note
- This does not auto-create draft parents before the user first saves; it removes the duplicate save action while preserving the existing validation and persistence flow.