### PR TITLE
Defer Xero login until invoices need sync

### DIFF
--- a/lib/api/xero/xero_invoice_payment_sync_service.dart
+++ b/lib/api/xero/xero_invoice_payment_sync_service.dart
@@ -9,6 +9,7 @@ import 'xero_api.dart';
 
 typedef XeroInvoicePaymentSyncErrorHandler =
     void Function(Object error, StackTrace stackTrace);
+typedef XeroLogin = Future<bool> Function({bool allowInteractive});
 
 class XeroInvoicePaymentSyncService {
   static DateTime? _lastAttempt;
@@ -16,11 +17,17 @@ class XeroInvoicePaymentSyncService {
   static const _minInterval = Duration(hours: 6);
 
   final XeroApi _xeroApi;
+  late final XeroLogin _login;
   final DaoInvoice _daoInvoice;
 
-  XeroInvoicePaymentSyncService({XeroApi? xeroApi, DaoInvoice? daoInvoice})
-    : _xeroApi = xeroApi ?? XeroApi(),
-      _daoInvoice = daoInvoice ?? DaoInvoice();
+  XeroInvoicePaymentSyncService({
+    XeroApi? xeroApi,
+    DaoInvoice? daoInvoice,
+    XeroLogin? login,
+  }) : _xeroApi = xeroApi ?? XeroApi(),
+       _daoInvoice = daoInvoice ?? DaoInvoice() {
+    _login = login ?? _xeroApi.login;
+  }
 
   Future<int> sync({
     bool force = false,
@@ -45,14 +52,19 @@ class XeroInvoicePaymentSyncService {
         return 0;
       }
 
-      final loggedIn = await _xeroApi.login(allowInteractive: false);
+      final pending = await _daoInvoice.getUploadedUnpaid();
+      if (pending.isEmpty) {
+        Log.i('Skipping Xero payment sync because no invoices need syncing.');
+        return 0;
+      }
+
+      final loggedIn = await _login(allowInteractive: false);
       if (!loggedIn) {
         Log.i(
           'Skipping Xero payment sync because silent login was unavailable.',
         );
         return 0;
       }
-      final pending = await _daoInvoice.getUploadedUnpaid();
       var updated = 0;
       for (final invoice in pending) {
         try {

--- a/test/api/xero/xero_invoice_payment_sync_service_test.dart
+++ b/test/api/xero/xero_invoice_payment_sync_service_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/api/xero/xero_invoice_payment_sync_service.dart';
+import 'package:hmb/dao/dao.g.dart';
+import 'package:hmb/entity/entity.g.dart';
+import 'package:hmb/util/dart/log.dart';
+
+import '../../database/management/db_utility_test_helper.dart';
+
+void main() {
+  setUpAll(() {
+    Log.configure('.');
+  });
+
+  setUp(() async {
+    await setupTestDb();
+    final system = await DaoSystem().get();
+    await DaoSystem().update(
+      system.copyWith(enableXeroIntegration: true, xeroClientId: 'client-id'),
+    );
+  });
+
+  tearDown(() async {
+    await tearDownTestDb();
+  });
+
+  test('does not attempt Xero login when no invoices need syncing', () async {
+    var loginAttempts = 0;
+    final service = XeroInvoicePaymentSyncService(
+      daoInvoice: _EmptyPendingInvoiceDao(),
+      login: ({allowInteractive = true}) async {
+        loginAttempts += 1;
+        return true;
+      },
+    );
+
+    final updated = await service.sync(force: true);
+
+    expect(updated, 0);
+    expect(loginAttempts, 0);
+  });
+}
+
+class _EmptyPendingInvoiceDao extends DaoInvoice {
+  @override
+  Future<List<Invoice>> getUploadedUnpaid() async => [];
+}


### PR DESCRIPTION
Fixes #355.

## Summary
- query local uploaded unpaid invoices before attempting silent Xero login during payment sync
- skip startup payment sync without touching Xero auth when there are no invoices needing remote state
- add a regression test covering the no-pending-invoices path

## Verification
- flutter test test/api/xero/xero_invoice_payment_sync_service_test.dart
- flutter analyze
- git diff --check