### PR TITLE
Add shopping item delete action

### DIFF
--- a/lib/ui/task_items/shopping_item_card.dart
+++ b/lib/ui/task_items/shopping_item_card.dart
@@ -14,7 +14,10 @@
 import 'package:flutter/material.dart';
 import 'package:future_builder_ex/future_builder_ex.dart';
 
+import '../../dao/dao.g.dart';
 import '../../util/dart/types.dart';
+import '../dialog/hmb_comfirm_delete_dialog.dart';
+import '../widgets/icons/hmb_delete_icon.dart';
 import '../widgets/icons/hmb_edit_icon.dart';
 import '../widgets/layout/layout.g.dart';
 import '../widgets/widgets.g.dart';
@@ -45,6 +48,14 @@ abstract class ShoppingItemCard extends StatelessWidget {
       title: itemContext.taskItem.description,
       actions: [
         buildActions(context, details!),
+        if (_canDeleteFromShoppingList)
+          HMBDeleteIcon(
+            onPressed: () async {
+              await _deleteItem(context);
+              await onReload();
+            },
+            hint: 'Delete Item',
+          ),
         HMBEditIcon(
           onPressed: () =>
               showShoppingItemDialog(context, itemContext, onReload),
@@ -65,4 +76,22 @@ abstract class ShoppingItemCard extends StatelessWidget {
       ),
     ),
   );
+
+  bool get _canDeleteFromShoppingList {
+    final taskItem = itemContext.taskItem;
+    return !taskItem.completed && !taskItem.billed && !taskItem.isReturn;
+  }
+
+  Future<void> _deleteItem(BuildContext context) async {
+    final taskItem = itemContext.taskItem;
+    await showConfirmDeleteDialog(
+      context: context,
+      nameSingular: 'Item',
+      question: 'Are you sure you want to delete ${taskItem.description}?',
+      onConfirmed: () async {
+        await DaoTaskItem().delete(taskItem.id);
+        HMBToast.info('Item deleted.');
+      },
+    );
+  }
 }

--- a/test/ui/task_items/list_shopping_screen_test.dart
+++ b/test/ui/task_items/list_shopping_screen_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/dao/dao.g.dart';
+import 'package:hmb/entity/entity.g.dart';
+import 'package:hmb/entity/helpers/charge_mode.dart';
+import 'package:hmb/ui/task_items/list_shopping_screen.dart';
+import 'package:hmb/util/dart/measurement_type.dart';
+import 'package:hmb/util/dart/units.dart';
+import 'package:money2/money2.dart';
+
+import '../../database/management/db_utility_test_helper.dart';
+import '../ui_test_helpers.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<void> waitForText(
+    WidgetTester tester,
+    String text, {
+    int attempts = 30,
+  }) async {
+    for (var i = 0; i < attempts; i++) {
+      if (find.text(text).evaluate().isNotEmpty) {
+        return;
+      }
+      await tester.runAsync(() async {
+        await Future<void>.delayed(const Duration(milliseconds: 50));
+      });
+      await tester.pump();
+    }
+    throw TestFailure('Timed out waiting for text: $text');
+  }
+
+  setUp(() async {
+    await setupTestDb();
+  });
+
+  tearDown(() async {
+    await tearDownTestDb();
+  });
+
+  testWidgets('shows delete action for shopping items', (tester) async {
+    await tester.runAsync(() async {
+      final job = await createJobWithCustomer(
+        billingType: BillingType.fixedPrice,
+        hourlyRate: Money.fromInt(5000, isoCode: 'AUD'),
+        bookingFee: Money.fromInt(10000, isoCode: 'AUD'),
+        summary: 'Shopping Delete Job',
+      );
+      job.status = JobStatus.scheduled;
+      await DaoJob().update(job);
+
+      final task = Task.forInsert(
+        jobId: job.id,
+        name: 'Shopping Task',
+        description: 'Task with shopping item',
+        status: TaskStatus.approved,
+      );
+      final taskId = await DaoTask().insert(task);
+
+      await DaoTaskItem().insert(
+        TaskItem.forInsert(
+          taskId: taskId,
+          description: 'Buy material item',
+          purpose: '',
+          itemType: TaskItemType.materialsBuy,
+          margin: Percentage.zero,
+          measurementType: MeasurementType.length,
+          dimension1: Fixed.fromNum(1, decimalDigits: 3),
+          dimension2: Fixed.fromNum(1, decimalDigits: 3),
+          dimension3: Fixed.fromNum(1, decimalDigits: 3),
+          units: Units.m,
+          url: '',
+          labourEntryMode: LabourEntryMode.hours,
+          chargeMode: ChargeMode.calculated,
+          estimatedMaterialUnitCost: Money.fromInt(1000, isoCode: 'AUD'),
+          estimatedMaterialQuantity: Fixed.fromNum(1, decimalDigits: 3),
+        ),
+      );
+    });
+
+    await tester.pumpWidget(const MaterialApp(home: ShoppingScreen()));
+    await tester.pumpAndSettle();
+    await waitForText(tester, 'Buy material item');
+
+    expect(find.text('Buy material item'), findsOneWidget);
+    expect(find.byIcon(Icons.check), findsWidgets);
+    expect(find.byIcon(Icons.delete), findsWidgets);
+  });
+}


### PR DESCRIPTION
Fixes #408

## Summary
- add a delete action to uncompleted, unbilled shopping-list task items
- reuse the existing delete confirmation flow and refresh the shopping list after deletion
- add a widget regression test for the shopping delete action; packing already had a delete action

## Verification
- flutter test test/ui/task_items/list_shopping_screen_test.dart test/ui/task_items/list_packing_screen_test.dart
- flutter analyze
- git diff --check