### PR TITLE
#489 Initialize time entry state

### DIFF
--- a/lib/ui/widgets/hmb_start_time_entry.dart
+++ b/lib/ui/widgets/hmb_start_time_entry.dart
@@ -50,7 +50,7 @@ class HMBStartTimeEntry extends StatefulWidget {
 
 class HMBStartTimeEntryState extends DeferredState<HMBStartTimeEntry> {
   Timer? _timer;
-  late TimeEntry? timeEntry;
+  TimeEntry? timeEntry;
 
   late Disposer disposer;
 


### PR DESCRIPTION
## Summary

Initializes the nullable `timeEntry` field in `HMBStartTimeEntryState` to `null` instead of leaving it `late`.

## Root Cause

The June listener installed in `initState` can run before `asyncInitState` assigns `timeEntry`. Because the field was declared `late`, that early read caused `LateInitializationError`.

## Validation

- `dart format lib/ui/widgets/hmb_start_time_entry.dart`
- `dart analyze lib/ui/widgets/hmb_start_time_entry.dart`

Fixes #489