### PR TITLE
#497 Keep photo sync awake

### DIFF
--- a/lib/database/management/backup_providers/google_drive/background_backup/photo_sync_service.dart
+++ b/lib/database/management/backup_providers/google_drive/background_backup/photo_sync_service.dart
@@ -20,10 +20,12 @@ import 'package:dcli_core/dcli_core.dart';
 import 'package:googleapis/drive/v3.dart' as gdrive;
 import 'package:path/path.dart' as p;
 import 'package:sentry/sentry.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
 import '../../../../../dao/dao_photo.dart';
 import '../../../../../dao/dao_photo_delete_queue.dart';
 import '../../../../../entity/entity.g.dart' show Photo;
+import '../../../../../util/dart/log.dart';
 import '../../../../../util/dart/paths.dart';
 import '../../progress_update.dart';
 import '../google_drive_api.dart';
@@ -79,6 +81,8 @@ class PhotoSyncService {
   Timer? _retryTimer;
   var _autoRetryAttempts = 0;
   var _syncHadError = false;
+  var _retryOnFailure = true;
+  var _wakeLockHeld = false;
   String? _lastErrorSummary;
 
   final StreamController<ProgressUpdate> _controller =
@@ -109,6 +113,7 @@ class PhotoSyncService {
     if (photos.isEmpty && deletes.isEmpty) {
       _autoRetryAttempts = 0;
       _lastErrorSummary = null;
+      await _releaseWakeLock();
       return;
     }
 
@@ -116,11 +121,13 @@ class PhotoSyncService {
       final headers = await (await GoogleDriveAuth.instance())
           .authHeadersOrNull(allowAutomaticSignIn: false);
       if (headers == null) {
+        await _releaseWakeLock();
         _controller.add(
           ProgressUpdate('Photo sync waiting for Google sign-in.', 0, 0),
         );
         return;
       }
+      await _enableWakeLock();
       await _startSync(
         photos: photos,
         deletes: deletes,
@@ -133,6 +140,10 @@ class PhotoSyncService {
       }
       _cleanup();
       _handleStartupFailure(error, stackTrace, retryOnFailure: retryOnFailure);
+    } finally {
+      if (!isRunning && !(_retryTimer?.isActive ?? false)) {
+        await _releaseWakeLock();
+      }
     }
   }
 
@@ -147,6 +158,7 @@ class PhotoSyncService {
     }
     _retryTimer?.cancel();
     _syncHadError = false;
+    _retryOnFailure = retryOnFailure;
     _lastErrorSummary = null;
 
     _receivePort = ReceivePort();
@@ -207,8 +219,10 @@ class PhotoSyncService {
   }
 
   void cancelSync() {
+    _retryTimer?.cancel();
     _isolate?.kill(priority: Isolate.immediate);
     _cleanup();
+    unawaited(_releaseWakeLock());
   }
 
   void _cleanup() {
@@ -224,6 +238,16 @@ class PhotoSyncService {
   void _onSyncError(dynamic error) {
     _syncHadError = true;
     _lastErrorSummary = _formatSyncError(error);
+    if (_shouldDeferRecoverableError(_lastErrorSummary!)) {
+      _controller.add(
+        ProgressUpdate(
+          'Photo sync was interrupted. It will retry shortly.',
+          0,
+          0,
+        ),
+      );
+      return;
+    }
     final exception = PhotoSyncException(_lastErrorSummary!);
     final stackTrace = _stackTraceFromIsolateError(error);
     unawaited(Sentry.captureException(exception, stackTrace: stackTrace));
@@ -244,9 +268,19 @@ class PhotoSyncService {
   }) {
     _syncHadError = true;
     _lastErrorSummary = _formatSyncError(error);
-    unawaited(Sentry.captureException(error, stackTrace: stackTrace));
-    _errorController.add(_lastErrorSummary!);
-    _controller.add(ProgressUpdate('Photo sync failed.', 0, 0));
+    if (_shouldDeferRecoverableError(_lastErrorSummary!)) {
+      _controller.add(
+        ProgressUpdate(
+          'Photo sync was interrupted. It will retry shortly.',
+          0,
+          0,
+        ),
+      );
+    } else {
+      unawaited(Sentry.captureException(error, stackTrace: stackTrace));
+      _errorController.add(_lastErrorSummary!);
+      _controller.add(ProgressUpdate('Photo sync failed.', 0, 0));
+    }
     if (retryOnFailure) {
       _scheduleRetry();
       return;
@@ -280,6 +314,9 @@ class PhotoSyncService {
     });
   }
 
+  bool _shouldDeferRecoverableError(String message) =>
+      _retryOnFailure && isRecoverablePhotoSyncError(message);
+
   String _formatSyncError(dynamic error) {
     if (error is Exception) {
       return error.toString();
@@ -307,6 +344,39 @@ class PhotoSyncService {
       }
     }
     return null;
+  }
+
+  Future<void> _enableWakeLock() async {
+    if (_wakeLockHeld) {
+      return;
+    }
+    try {
+      await WakelockPlus.enable();
+      _wakeLockHeld = true;
+    } catch (error, stackTrace) {
+      Log.w(
+        'Photo sync could not enable wakelock.',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> _releaseWakeLock() async {
+    if (!_wakeLockHeld) {
+      return;
+    }
+    try {
+      await WakelockPlus.disable();
+    } catch (error, stackTrace) {
+      Log.w(
+        'Photo sync could not release wakelock.',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    } finally {
+      _wakeLockHeld = false;
+    }
   }
 
   Future<void> resumeIfNeeded() async {
@@ -458,6 +528,22 @@ properties has { key='photoId' and value='$idStr' } and trashed=false''';
     // (You could sort by modifiedTime if you request that field.)
     return files.first;
   }
+}
+
+bool isRecoverablePhotoSyncError(String message) {
+  final lowerMessage = message.toLowerCase();
+  return lowerMessage.contains('timeout') ||
+      lowerMessage.contains('timed out') ||
+      lowerMessage.contains('socketexception') ||
+      lowerMessage.contains('clientexception') ||
+      lowerMessage.contains('connection closed') ||
+      lowerMessage.contains('connection reset') ||
+      lowerMessage.contains('connection refused') ||
+      lowerMessage.contains('connection aborted') ||
+      lowerMessage.contains('broken pipe') ||
+      lowerMessage.contains('failed host lookup') ||
+      lowerMessage.contains('network is unreachable') ||
+      lowerMessage.contains('software caused connection abort');
 }
 
 /// In the isolate, after each successful upload, send the payload itself:

--- a/lib/database/management/backup_providers/google_drive/google_drive_backup_screen.dart
+++ b/lib/database/management/backup_providers/google_drive/google_drive_backup_screen.dart
@@ -271,7 +271,6 @@ class _GoogleDriveBackupScreenState
       hint: 'Copy your photos to google drive - including receipts and tools',
       icon: const Icon(Icons.cloud_upload, size: 24),
       onPressed: () async {
-        await WakelockPlus.enable();
         try {
           _syncRunning = true;
           await _provider.syncPhotos();
@@ -292,7 +291,6 @@ class _GoogleDriveBackupScreenState
           }
         } finally {
           _syncRunning = false;
-          await WakelockPlus.disable();
         }
       },
     ),

--- a/lib/ui/nav/dashboards/backup/backup_dashboard.dart
+++ b/lib/ui/nav/dashboards/backup/backup_dashboard.dart
@@ -251,8 +251,6 @@ class _BackupDashboardPageState extends DeferredState<BackupDashboardPage> {
     if (!await _ensureSignedInForAction()) {
       return;
     }
-    // Sync Photos Button
-    await WakelockPlus.enable();
     try {
       _syncRunning = true;
       await _provider.syncPhotos();
@@ -273,7 +271,6 @@ class _BackupDashboardPageState extends DeferredState<BackupDashboardPage> {
       }
     } finally {
       _syncRunning = false;
-      await WakelockPlus.disable();
     }
   }
 

--- a/test/database/management/backup_providers/google_drive/background_backup/photo_sync_service_test.dart
+++ b/test/database/management/backup_providers/google_drive/background_backup/photo_sync_service_test.dart
@@ -1,0 +1,48 @@
+@Tags(['flutter'])
+// ignore_for_file: lines_longer_than_80_chars
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/database/management/backup_providers/google_drive/background_backup/photo_sync_service.dart';
+
+void main() {
+  group('isRecoverablePhotoSyncError', () {
+    test('matches transient network and sleep interruption messages', () {
+      expect(
+        isRecoverablePhotoSyncError(
+          'SocketException: Software caused connection abort',
+        ),
+        isTrue,
+      );
+      expect(
+        isRecoverablePhotoSyncError(
+          'ClientException: Connection closed before full header was received',
+        ),
+        isTrue,
+      );
+      expect(
+        isRecoverablePhotoSyncError(
+          'TimeoutException: Timed out after 120s while uploading photo 12.',
+        ),
+        isTrue,
+      );
+      expect(
+        isRecoverablePhotoSyncError('SocketException: Failed host lookup'),
+        isTrue,
+      );
+    });
+
+    test('does not match permanent service errors', () {
+      expect(
+        isRecoverablePhotoSyncError(
+          'HttpException: Failed to initialize resumable upload: 403 forbidden',
+        ),
+        isFalse,
+      );
+      expect(
+        isRecoverablePhotoSyncError('StateError: Google Drive auth missing'),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #497.

- Move photo-sync wake-lock handling into `PhotoSyncService` so manual sync and lifecycle resume sync use the same protection.
- Keep the wake lock active across scheduled photo-sync retries, and release it when there is no work, auth is unavailable, sync completes, or sync is cancelled.
- Suppress recoverable transient network/sleep interruption errors from the user-facing error stream while the retry path is active.
- Remove duplicated photo-sync wake-lock calls from the backup UI entry points.

## Validation

- `flutter test test/database/management/backup_providers/google_drive/background_backup/photo_sync_service_test.dart`
- `flutter analyze`