### PR TITLE
#499 Balance paid customer statement invoices

### DIFF
--- a/lib/api/xero/xero_invoice_payment_sync_service.dart
+++ b/lib/api/xero/xero_invoice_payment_sync_service.dart
@@ -110,18 +110,23 @@ class XeroInvoicePaymentSyncService {
               remoteState.externalSyncStatus,
             );
           }
-          if (remoteState.paidDate != null) {
+          if (remoteState.paidDate != null &&
+              _needsPaidUpdate(invoice, remoteState.paidDate!)) {
             await _daoInvoice.markPaidFromXero(
               invoice.id,
               paidDate: remoteState.paidDate,
             );
+            updated += 1;
           }
           updated += await _importPayments(invoice, remoteState.payments);
           updated += await _importCreditNotes(invoice, remoteState.creditNotes);
           if (remoteState.paidDate != null &&
               remoteState.payments.isEmpty &&
               remoteState.creditNotes.isEmpty) {
-            updated += 1;
+            Log.i(
+              'Xero invoice ${invoice.id} is paid but returned no payment '
+              'rows. Keeping it eligible for a later payment sync.',
+            );
           }
         } catch (e, st) {
           Log.e('Failed to sync payment for invoice ${invoice.id}: $e\n$st');
@@ -304,6 +309,11 @@ class XeroInvoicePaymentSyncService {
       creditNotes: _parseCreditNotes(remote['CreditNotes']),
     );
   }
+
+  bool _needsPaidUpdate(Invoice invoice, DateTime paidDate) =>
+      !invoice.paid ||
+      invoice.paymentSource != InvoicePaymentSource.xero ||
+      invoice.paidDate?.toIso8601String() != paidDate.toIso8601String();
 
   Future<int> _importPayments(
     Invoice invoice,

--- a/lib/dao/accounting_report_service.dart
+++ b/lib/dao/accounting_report_service.dart
@@ -445,7 +445,18 @@ class AccountingReportService {
         );
       }
 
-      for (final history in await ledgerService.invoiceHistory(invoice.id)) {
+      final historyEntries = await ledgerService.invoiceHistory(invoice.id);
+      if (invoice.paid && historyEntries.isEmpty) {
+        _addPaidInvoiceEntry(
+          entries: entries,
+          invoice: invoice,
+          openingBalance: (amount) => openingBalance += amount,
+          startInclusive: startInclusive,
+          endExclusive: endExclusive,
+        );
+      }
+
+      for (final history in historyEntries) {
         final amount = -history.amount;
         if (history.date.isBefore(startInclusive)) {
           openingBalance += amount;
@@ -475,6 +486,33 @@ class AccountingReportService {
       endExclusive: endExclusive,
       openingBalance: openingBalance,
       entries: entries,
+    );
+  }
+
+  void _addPaidInvoiceEntry({
+    required List<DebtorStatementEntry> entries,
+    required Invoice invoice,
+    required void Function(Money amount) openingBalance,
+    required DateTime startInclusive,
+    required DateTime endExclusive,
+  }) {
+    final paymentDate = invoice.paidDate ?? invoice.modifiedDate;
+    final amount = -invoice.totalAmount;
+    if (paymentDate.isBefore(startInclusive)) {
+      openingBalance(amount);
+      return;
+    }
+    if (!paymentDate.isBefore(endExclusive)) {
+      return;
+    }
+    entries.add(
+      DebtorStatementEntry(
+        type: DebtorStatementEntryType.payment,
+        invoiceId: invoice.id,
+        date: paymentDate,
+        description: 'Payment received - Invoice #${invoice.bestNumber}',
+        amount: amount,
+      ),
     );
   }
 

--- a/lib/dao/dao_invoice.dart
+++ b/lib/dao/dao_invoice.dart
@@ -194,7 +194,23 @@ SELECT *
 FROM invoice
 WHERE external_invoice_id IS NOT NULL
   AND external_invoice_id != ''
-  AND IFNULL(paid, 0) = 0
+  AND (
+    IFNULL(paid, 0) = 0
+    OR (
+      NOT EXISTS (
+        SELECT 1 FROM debtor_payment_allocation pa
+        WHERE pa.invoice_id = invoice.id
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM credit_allocation ca
+        WHERE ca.invoice_id = invoice.id
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM debtor_adjustment da
+        WHERE da.invoice_id = invoice.id
+      )
+    )
+  )
   AND IFNULL(external_sync_status, 0) NOT IN (
     ${InvoiceExternalSyncStatus.deleted.ordinal},
     ${InvoiceExternalSyncStatus.voided.ordinal}

--- a/test/api/xero/xero_invoice_payment_sync_service_test.dart
+++ b/test/api/xero/xero_invoice_payment_sync_service_test.dart
@@ -124,6 +124,84 @@ void main() {
     expect(secondRun, 0);
   });
 
+  test('retries paid Xero invoices until payment rows are available', () async {
+    final job = await createJobWithCustomer(
+      billingType: BillingType.timeAndMaterial,
+      hourlyRate: MoneyEx.zero,
+      summary: 'Xero paid debtor ledger job',
+    );
+    final invoice = Invoice.forInsert(
+      jobId: job.id,
+      dueDate: LocalDate.today(),
+      totalAmount: MoneyEx.dollars(100),
+      billingContactId: job.billingContactId,
+      sent: true,
+      paid: true,
+      paidDate: DateTime(2026, 5, 3),
+      externalInvoiceId: 'xero-paid-without-payments',
+      externalSyncStatus: InvoiceExternalSyncStatus.linked,
+      paymentSource: InvoicePaymentSource.xero,
+    );
+    await DaoInvoice().insert(invoice);
+    var calls = 0;
+    final service = XeroInvoicePaymentSyncService(
+      login: ({allowInteractive = true}) async => true,
+      getInvoice: (_) async {
+        calls += 1;
+        return http.Response(
+          jsonEncode({
+            'Invoices': [
+              {
+                'Status': 'PAID',
+                'AmountDue': 0,
+                'AmountPaid': 100,
+                'FullyPaidOnDate': '2026-05-03',
+                'Payments': calls == 1
+                    ? <Map<String, dynamic>>[]
+                    : [
+                        {
+                          'PaymentID': 'xero-payment-late',
+                          'Amount': 100,
+                          'Date': '2026-05-03',
+                        },
+                      ],
+                'CreditNotes': <Map<String, dynamic>>[],
+              },
+            ],
+          }),
+          200,
+        );
+      },
+    );
+
+    final firstRun = await service.sync(force: true);
+
+    expect(firstRun, 0);
+    expect(
+      await DebtorLedgerService().invoicePaidAmount(invoice.id),
+      MoneyEx.zero,
+    );
+    expect(await DaoInvoice().getUploadedUnpaid(), hasLength(1));
+
+    final secondRun = await service.sync(force: true);
+    expect(secondRun, 1);
+    expect(
+      await DebtorLedgerService().invoicePaidAmount(invoice.id),
+      MoneyEx.dollars(100),
+    );
+    expect(
+      await DebtorLedgerService().invoiceBalance(invoice.id),
+      MoneyEx.zero,
+    );
+    expect(
+      await DaoDebtorPayment().getByExternalPaymentId(
+        provider: 'xero',
+        externalPaymentId: 'xero-payment-late',
+      ),
+      isNotNull,
+    );
+  });
+
   test('pushes local payments to Xero and stores external ids', () async {
     final job = await createJobWithCustomer(
       billingType: BillingType.timeAndMaterial,

--- a/test/dao/accounting_report_service_test.dart
+++ b/test/dao/accounting_report_service_test.dart
@@ -244,6 +244,39 @@ void main() {
     },
   );
 
+  test(
+    'debtor statement balances paid invoices without local allocations',
+    () async {
+      final job = await createJobWithCustomer(
+        billingType: BillingType.timeAndMaterial,
+        hourlyRate: MoneyEx.zero,
+        summary: 'Paid debtor statement report test job',
+      );
+      final invoice = await _insertInvoice(
+        job,
+        MoneyEx.dollars(100),
+        createdDate: DateTime(2026, 4, 3),
+        paid: true,
+        paidDate: DateTime(2026, 4, 8),
+      );
+
+      final report = await AccountingReportService().debtorStatement(
+        customerId: job.customerId,
+        startInclusive: DateTime(2026, 4),
+        endExclusive: DateTime(2026, 5),
+      );
+
+      expect(report.openingBalance, MoneyEx.zero);
+      expect(report.entries.map((entry) => entry.type), [
+        DebtorStatementEntryType.invoice,
+        DebtorStatementEntryType.payment,
+      ]);
+      expect(report.entries.last.invoiceId, invoice.id);
+      expect(report.entries.last.amount, -MoneyEx.dollars(100));
+      expect(report.closingBalance, MoneyEx.zero);
+    },
+  );
+
   test('cash received reports allocated payment rows', () async {
     final job = await createJobWithCustomer(
       billingType: BillingType.timeAndMaterial,
@@ -425,6 +458,8 @@ Future<Invoice> _insertInvoice(
   Money total, {
   LocalDate? dueDate,
   DateTime? createdDate,
+  bool paid = false,
+  DateTime? paidDate,
 }) async {
   final invoice = Invoice.forInsert(
     jobId: job.id,
@@ -432,6 +467,8 @@ Future<Invoice> _insertInvoice(
     totalAmount: total,
     billingContactId: job.billingContactId,
     sent: true,
+    paid: paid,
+    paidDate: paidDate,
   );
   await DaoInvoice().insert(invoice);
   if (createdDate == null) {


### PR DESCRIPTION
## Summary

Fixes #499.

- Add a customer-statement payment entry for paid invoices that have no local debtor ledger history, so existing Xero-paid invoices no longer inflate statement balances.
- Update Xero payment sync to keep paid Xero invoices with no local ledger history eligible for later sync instead of fabricating a persisted payment row.
- When Xero later returns the real payment row, import that real `PaymentID` into the debtor ledger.
- Add regression tests for both the statement fallback and the delayed Xero payment-row sync path.

## Validation

- `dart test test/api/xero/xero_invoice_payment_sync_service_test.dart`
- `dart test test/dao/accounting_report_service_test.dart`
- `flutter analyze`