### PR TITLE
#566 Open estimator after fixed-price conversion

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -8,9 +8,19 @@
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 	<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+	<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
 	<!-- backup_ruiles and data_extraction_rules required by oidc package -->
 	<application android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:enableOnBackInvokedCallback="true" android:fullBackupContent="@xml/backup_rules" android:dataExtractionRules="@xml/data_extraction_rules">
+		<receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver" />
+		<receiver android:exported="false" android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver">
+			<intent-filter>
+				<action android:name="android.intent.action.BOOT_COMPLETED" />
+				<action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
+				<action android:name="android.intent.action.QUICKBOOT_POWERON" />
+				<action android:name="com.htc.intent.action.QUICKBOOT_POWERON" />
+			</intent-filter>
+		</receiver>
 		<activity android:name=".MainActivity" android:exported="true" android:launchMode="singleTask" android:theme="@style/LaunchTheme" android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode" android:hardwareAccelerated="true" android:windowSoftInputMode="adjustResize">
 			<!--
 			Specifies an Android theme to apply to this Activity as soon as

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Flutter
+import UserNotifications
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
@@ -7,6 +8,9 @@ import Flutter
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    if #available(iOS 10.0, *) {
+      UNUserNotificationCenter.current().delegate = self
+    }
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/lib/dao/dao_job_activity.dart
+++ b/lib/dao/dao_job_activity.dart
@@ -151,4 +151,20 @@ SELECT ja.*
 
     return fromMap(data.first);
   }
+
+  Future<List<JobActivity>> getStartingAfter(DateTime date) async {
+    final db = withoutTransaction();
+    final rows = await db.rawQuery(
+      '''
+SELECT ja.*
+  FROM $tableName ja
+  JOIN job j ON ja.job_id = j.id
+ WHERE ja.start_date > ?
+   AND j.status_id NOT IN (?, ?)
+ ORDER BY ja.start_date ASC
+''',
+      [date.toIso8601String(), JobStatus.rejected.id, JobStatus.completed.id],
+    );
+    return rows.map(fromMap).toList();
+  }
 }

--- a/lib/entity/todo.dart
+++ b/lib/entity/todo.dart
@@ -92,6 +92,22 @@ class ToDo extends Entity<ToDo> {
     modifiedDate: DateTime.now(),
   );
 
+  /// Changes the due date and keeps an invalidated reminder the same distance
+  /// ahead of it.
+  ToDo withDueDate(DateTime newDueDate) {
+    final currentReminder = remindAt;
+    var adjustedReminder = currentReminder;
+
+    if (currentReminder != null && currentReminder.isAfter(newDueDate)) {
+      final reminderLeadTime = dueDate?.difference(currentReminder);
+      adjustedReminder = reminderLeadTime == null || reminderLeadTime.isNegative
+          ? newDueDate
+          : newDueDate.subtract(reminderLeadTime);
+    }
+
+    return copyWith(dueDate: newDueDate, remindAt: adjustedReminder);
+  }
+
   factory ToDo.fromMap(Map<String, dynamic> map) => ToDo(
     id: map['id'] as int,
     title: map['title'] as String,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -127,6 +127,12 @@ class _HmbAppState extends State<HmbApp> with WidgetsBindingObserver {
         return;
       }
       GoRouter.of(context).go('/home/todo');
+    } else if (type == 'job_reminder') {
+      final context = _rootNavKey.currentContext;
+      if (context == null) {
+        return;
+      }
+      GoRouter.of(context).go('/home/schedule');
     }
   }
 

--- a/lib/ui/crud/job/estimator/edit_job_estimate_screen.dart
+++ b/lib/ui/crud/job/estimator/edit_job_estimate_screen.dart
@@ -77,6 +77,11 @@ class _JobEstimateBuilderScreenState
 
   @override
   Future<void> asyncInitState() async {
+    await WidgetsBinding.instance.endOfFrame;
+    if (!mounted) {
+      return;
+    }
+
     final canProceed = await _ensureFixedPrice();
     if (!canProceed) {
       if (mounted) {

--- a/lib/ui/crud/job/mini_job_dashboard.dart
+++ b/lib/ui/crud/job/mini_job_dashboard.dart
@@ -110,14 +110,14 @@ class MiniJobDashboard extends StatelessWidget {
               size: dashletSize,
             ),
             _dashlet(
-              child: DashletCard<String>.onTap(
+              child: DashletCard<String>.builder(
                 label: 'Estimate',
                 hint: "Build an Estimate of a Job's cost",
                 icon: Icons.calculate,
                 compact: true,
                 onBeforeOpen: _markJobAccessed,
                 value: () async => const DashletValue(''),
-                onTap: _openEstimateBuilder,
+                builder: (_, _) => JobEstimateBuilderScreen(job: job),
               ),
               size: dashletSize,
             ),
@@ -249,52 +249,6 @@ class MiniJobDashboard extends StatelessWidget {
           .length;
     }
     return DashletValue<int>(outstandingMilestones);
-  }
-
-  Future<void> _openEstimateBuilder(BuildContext context) async {
-    if (job.billingType == BillingType.timeAndMaterial) {
-      final switchToFixed = await showDialog<bool>(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text('Estimates Require Fixed Price'),
-          content: const Text(
-            'You cannot create estimates for Time and Materials jobs. '
-            'Switch this job to Fixed Price to continue?',
-          ),
-          actions: [
-            HMBButton(
-              label: 'Cancel',
-              hint: "Don't switch the job billing type",
-              onPressed: () => Navigator.pop(context, false),
-            ),
-            HMBButton(
-              label: 'Switch to Fixed Price',
-              hint: 'Update the job to Fixed Price billing',
-              onPressed: () => Navigator.pop(context, true),
-            ),
-          ],
-        ),
-      );
-
-      if (switchToFixed != true) {
-        return;
-      }
-
-      final updated = job.copyWith(billingType: BillingType.fixedPrice);
-      await DaoJob().update(updated);
-      job.billingType = updated.billingType;
-    }
-
-    if (!context.mounted) {
-      return;
-    }
-
-    await Navigator.of(context).push<void>(
-      MaterialPageRoute<void>(
-        builder: (_) => JobEstimateBuilderScreen(job: job),
-        fullscreenDialog: true,
-      ),
-    );
   }
 
   Future<void> _openMilestones(BuildContext context) async {

--- a/lib/ui/crud/todo/edit_todo_card.dart
+++ b/lib/ui/crud/todo/edit_todo_card.dart
@@ -162,7 +162,7 @@ class _ToDoEditorCardState extends State<ToDoEditorCard> {
               DateTime.now()
                   .add(const Duration(days: 3))
                   .withTime(const LocalTime(hour: 9, minute: 0)),
-          onChanged: (d) => _emit(v.copyWith(dueDate: d)),
+          onChanged: (d) => _emit(v.withDueDate(d)),
         ),
 
         // Reminder

--- a/lib/ui/dialog/message_template_dialog.dart
+++ b/lib/ui/dialog/message_template_dialog.dart
@@ -11,6 +11,8 @@
  https://github.com/bsutton/hmb/blob/main/LICENSE
 */
 
+import 'dart:async';
+
 import 'package:deferred_state/deferred_state.dart';
 import 'package:flutter/material.dart';
 import 'package:future_builder_ex/future_builder_ex.dart';
@@ -28,8 +30,13 @@ import 'source_context.dart';
 
 class MessageTemplateDialog extends StatefulWidget {
   final SourceContext sourceContext;
+  final MessageType? messageType;
 
-  const MessageTemplateDialog({required this.sourceContext, super.key});
+  const MessageTemplateDialog({
+    required this.sourceContext,
+    this.messageType,
+    super.key,
+  });
 
   @override
   _MessageTemplateDialogState createState() => _MessageTemplateDialogState();
@@ -38,9 +45,13 @@ class MessageTemplateDialog extends StatefulWidget {
 Future<SelectedMessageTemplate?> showMessageTemplateDialog(
   BuildContext context, {
   required SourceContext sourceContext,
+  MessageType? messageType,
 }) => Navigator.of(context).push(
   MaterialPageRoute(
-    builder: (context) => MessageTemplateDialog(sourceContext: sourceContext),
+    builder: (context) => MessageTemplateDialog(
+      sourceContext: sourceContext,
+      messageType: messageType,
+    ),
   ),
 );
 
@@ -53,6 +64,7 @@ class _MessageTemplateDialogState extends DeferredState<MessageTemplateDialog>
 
   late TabController _tabController;
   final _messageController = TextEditingController();
+  var _selectionGeneration = 0;
 
   @override
   Future<void> asyncInitState() async {
@@ -64,6 +76,9 @@ class _MessageTemplateDialogState extends DeferredState<MessageTemplateDialog>
   Future<void> _loadTemplates() async {
     final templates = await DaoMessageTemplate().getByFilter(null);
     final filtered = await _filterTemplates(templates);
+    if (!mounted) {
+      return;
+    }
     setState(() {
       _templates = filtered;
     });
@@ -74,6 +89,11 @@ class _MessageTemplateDialogState extends DeferredState<MessageTemplateDialog>
   ) async {
     final filtered = <MessageTemplate>[];
     for (final template in templates) {
+      if (!template.enabled ||
+          (widget.messageType != null &&
+              template.messageType != widget.messageType)) {
+        continue;
+      }
       final names = _extractPlaceholderNames(template.message);
       var canUse = true;
       for (final name in names) {
@@ -126,43 +146,47 @@ class _MessageTemplateDialogState extends DeferredState<MessageTemplateDialog>
     }
   }
 
-  Future<void> _initializePlaceholders() async {
-    if (_selectedTemplate != null) {
-      final newPlaceholders = _extractPlaceholderNames(
-        _selectedTemplate!.message,
+  Future<void> _selectTemplate(MessageTemplate template) async {
+    final generation = ++_selectionGeneration;
+    _selectedTemplate = template;
+    _messageController.text = template.message;
+    placeholders.clear();
+    setState(() {});
+
+    final resolved = <String, PlaceHolder<dynamic>>{};
+    for (final name in _extractPlaceholderNames(template.message)) {
+      final placeholder = await PlaceHolderManager().resolvePlaceholder(
+        name,
+        widget.sourceContext,
       );
-
-      // Remove placeholders that are no longer in the new template
-      placeholders.entries
-          .where((field) => !newPlaceholders.contains(field.key))
-          .toList()
-          .forEach(placeholders.remove);
-
-      // Add new placeholders or keep existing ones
-      for (final name in newPlaceholders) {
-        final placeholder = await PlaceHolderManager().resolvePlaceholder(
-          name,
-          widget.sourceContext,
-        );
-
-        if (placeholder != null) {
-          /// provide each source with an initial value
-          placeholder.source.dependencyChanged(
-            NoopSource(),
-            widget.sourceContext,
-          );
-
-          // listen to source changes and propergate them to
-          // other sources and the preview window.
-          placeholder.listen = (value, reset) {
-            placeholder.source.revise(widget.sourceContext);
-            _reset(placeholder.source, reset);
-            _refreshPreview();
-          };
-          placeholders[placeholder.name] = placeholder;
-        }
+      if (!mounted || generation != _selectionGeneration) {
+        return;
       }
+      if (placeholder == null) {
+        continue;
+      }
+
+      placeholder.source.dependencyChanged(NoopSource(), widget.sourceContext);
+      placeholder.listen = (value, reset) {
+        placeholder.source.revise(widget.sourceContext);
+        _reset(placeholder.source, reset);
+        _refreshPreview();
+      };
+      resolved[placeholder.name] = placeholder;
     }
+
+    placeholders
+      ..clear()
+      ..addAll(resolved);
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _selectionGeneration++;
+    _messageController.dispose();
+    _tabController.dispose();
+    super.dispose();
   }
 
   /// Preview window
@@ -227,11 +251,10 @@ class _MessageTemplateDialogState extends DeferredState<MessageTemplateDialog>
                             )
                             .toList(),
                   format: (template) => template.title,
-                  onChanged: (template) async {
-                    _selectedTemplate = template;
-                    await _initializePlaceholders();
-                    _messageController.text = _selectedTemplate?.message ?? '';
-                    setState(() {});
+                  onChanged: (template) {
+                    if (template != null) {
+                      unawaited(_selectTemplate(template));
+                    }
                   },
                 ),
                 if (_selectedTemplate != null) _buildSourceWidgets(),
@@ -340,7 +363,9 @@ class _MessageTemplateDialogState extends DeferredState<MessageTemplateDialog>
   }
 
   void _refreshPreview() {
-    setState(() {});
+    if (mounted) {
+      setState(() {});
+    }
   }
 
   void _reset(Source<dynamic> source, ResetFields reset) {

--- a/lib/ui/dialog/send_notice_for_job_dialog.dart
+++ b/lib/ui/dialog/send_notice_for_job_dialog.dart
@@ -27,6 +27,8 @@ import '../widgets/hmb_toast.dart';
 import '../widgets/icons/help_button.dart';
 import '../widgets/select/hmb_select_email_multi.dart';
 import '../widgets/select/hmb_select_mobile_multi.dart';
+import 'message_template_dialog.dart';
+import 'source_context.dart';
 
 enum NoticeChannel { email, sms }
 
@@ -189,6 +191,15 @@ ${Strings.isNotBlank(_system.businessNumber) ? '${Strings.orElseOnBlank(_system.
             const SizedBox(height: 12),
 
             if (_channel == NoticeChannel.sms) ...[
+              Align(
+                alignment: Alignment.centerRight,
+                child: HMBButtonSecondary(
+                  label: 'Use Template',
+                  hint: 'Pick an SMS template and apply placeholders.',
+                  onPressed: _applySmsTemplate,
+                ),
+              ),
+              const SizedBox(height: 8),
               HMBSelectMobileMulti(
                 job: widget.job,
                 initialMobiles: _toMobiles,
@@ -261,6 +272,21 @@ Add additional recipients who should receive a copy of the email.'''),
     ),
   );
 
+  Future<void> _applySmsTemplate() async {
+    final selected = await showMessageTemplateDialog(
+      context,
+      sourceContext: SourceContext(
+        job: widget.job,
+        jobActivity: widget.jobActivity,
+      ),
+      messageType: MessageType.sms,
+    );
+    if (!mounted || selected == null) {
+      return;
+    }
+    _smsBodyCtl.text = selected.getFormattedMessage();
+  }
+
   Future<void> _sendSms(BuildContext context) async {
     if (_toMobiles.isEmpty) {
       HMBToast.info('Please select at least one mobile number');
@@ -321,6 +347,9 @@ Add additional recipients who should receive a copy of the email.'''),
   }
 
   Future<void> _stampNoticeSent() async {
+    if (widget.jobActivity.id <= 0) {
+      return;
+    }
     final updated = widget.jobActivity.copyWith(noticeSentDate: DateTime.now());
     await DaoJobActivity().update(updated);
   }

--- a/lib/ui/nav/boot_strapper.dart
+++ b/lib/ui/nav/boot_strapper.dart
@@ -176,6 +176,17 @@ class BootStrapper {
   Future<void> _initScheduler() async {
     final openTodos = await DaoToDo().getOpenWithReminders();
     await LocalNotifs().resyncFromToDos(openTodos);
+
+    final activities = await DaoJobActivity().getStartingAfter(DateTime.now());
+    for (final activity in activities) {
+      final job = await DaoJob().getById(activity.jobId);
+      if (job != null) {
+        await LocalNotifs().syncForJobActivity(
+          activity,
+          jobSummary: job.summary,
+        );
+      }
+    }
   }
 
   Future<void> _initializeTimeEntryState({required bool refresh}) async {

--- a/lib/ui/scheduling/job_activity_dialog.dart
+++ b/lib/ui/scheduling/job_activity_dialog.dart
@@ -543,6 +543,18 @@ class _JobActivityDialogState extends DeferredState<JobActivityDialog> {
   }
 
   Future<void> _showContactOptions() async {
+    final job = await DaoJob().getById(_selectedJob.jobId);
+    if (job == null) {
+      HMBToast.error('Please select a valid job first');
+      return;
+    }
+
+    final jobActivity = _buildCurrentJobActivityForNotice();
+    if (jobActivity == null) {
+      HMBToast.error('Please complete schedule start/end first');
+      return;
+    }
+
     // Fetch customer contacts
     final contacts = await _getCustomerContacts();
 
@@ -581,11 +593,7 @@ class _JobActivityDialogState extends DeferredState<JobActivityDialog> {
                 ),
                 onTap: () async {
                   Navigator.of(context).pop();
-                  await _sendNotice(
-                    contact,
-                    widget.event!.event!.job,
-                    widget.event!.event!.jobActivity,
-                  );
+                  await _sendNotice(contact, job, jobActivity);
                 },
               );
             },
@@ -665,7 +673,7 @@ class _JobActivityDialogState extends DeferredState<JobActivityDialog> {
           ? NoticeChannel.email
           : NoticeChannel.sms,
     );
-    if (!sent) {
+    if (!sent || !mounted) {
       return;
     }
 
@@ -673,6 +681,35 @@ class _JobActivityDialogState extends DeferredState<JobActivityDialog> {
     setState(() {
       _noticeSentDate = DateTime.now();
     });
+  }
+
+  JobActivity? _buildCurrentJobActivityForNotice() {
+    final jobId = _selectedJob.jobId;
+    if (jobId == null) {
+      return null;
+    }
+    final start = _startTime.atDate(_eventDate);
+    final end = _endTime.atDate(_eventDate);
+    if (!start.isBefore(end)) {
+      return null;
+    }
+
+    return widget.event?.event?.jobActivity.copyWith(
+          jobId: jobId,
+          start: start,
+          end: end,
+          status: _status,
+          notes: _notes,
+          noticeSentDate: _noticeSentDate,
+        ) ??
+        JobActivity.forInsert(
+          jobId: jobId,
+          start: start,
+          end: end,
+          status: _status,
+          notes: _notes,
+          noticeSentDate: _noticeSentDate,
+        );
   }
 
   List<Widget> _buildStartEndDates(bool isSmallScreen) {

--- a/lib/ui/scheduling/schedule_helper.dart
+++ b/lib/ui/scheduling/schedule_helper.dart
@@ -17,7 +17,9 @@ import 'package:flutter/material.dart';
 import '../../dao/dao_job_activity.dart';
 import '../../util/dart/format.dart';
 import '../../util/dart/local_date.dart';
+import '../../util/flutter/notifications/local_notifs.dart';
 import '../dialog/send_notice_for_job_dialog.dart';
+import '../widgets/hmb_toast.dart';
 import 'job_activity_dialog.dart';
 import 'job_activity_ex.dart';
 
@@ -63,6 +65,7 @@ mixin ScheduleHelper {
           jobActivityAction.jobActivity!.jobActivity,
         );
         jobActivityAction.jobActivity!.jobActivity.id = newId;
+        await _syncActivityReminder(jobActivityAction.jobActivity!);
         if (!context.mounted) {
           return;
         }
@@ -120,12 +123,26 @@ mixin ScheduleHelper {
 
     // 1) Update DB
     await dao.update(updated.jobActivity);
+    await _syncActivityReminder(updated);
   }
 
   /// Delete an existing activity from the DB
   Future<void> _deleteActivity(JobActivityEx activity) async {
     final dao = DaoJobActivity();
     await dao.delete(activity.jobActivity.id);
+    await LocalNotifs().cancelForJobActivity(activity.jobActivity.id);
+  }
+
+  Future<void> _syncActivityReminder(JobActivityEx activity) async {
+    final synced = await LocalNotifs().syncForJobActivity(
+      activity.jobActivity,
+      jobSummary: activity.job.summary,
+    );
+    if (!synced) {
+      HMBToast.info(
+        'Schedule saved, but reminder notifications are unavailable.',
+      );
+    }
   }
 
   /// header style

--- a/lib/ui/widgets/hmb_start_time_entry.dart
+++ b/lib/ui/widgets/hmb_start_time_entry.dart
@@ -108,8 +108,12 @@ class HMBStartTimeEntryState extends DeferredState<HMBStartTimeEntry> {
                 _isSameTimeEntry(timeEntry, timeEntryState.activeTimeEntry);
 
             return IconButton(
-              padding: const EdgeInsets.only(top: 8, bottom: 8),
-              visualDensity: const VisualDensity(horizontal: -4),
+              constraints: const BoxConstraints.tightFor(
+                width: kMinInteractiveDimension,
+                height: kMinInteractiveDimension,
+              ),
+              padding: const EdgeInsets.all(8),
+              tooltip: isActive ? 'Stop task timer' : 'Start task timer',
               // start / stop icon
               icon: Icon(
                 isActive ? Icons.stop : Icons.play_arrow,

--- a/lib/util/dart/measurement_type.dart
+++ b/lib/util/dart/measurement_type.dart
@@ -34,8 +34,8 @@ class MeasurementType {
 
   static const area = MeasurementType(
     name: 'area',
-    defaultMetric: Units.m2,
-    defaultImperial: Units.yd2,
+    defaultMetric: Units.mm2,
+    defaultImperial: Units.ft2,
     metric: [Units.m2, Units.cm2, Units.mm2],
     imperial: [Units.yd2, Units.ft2],
   );

--- a/lib/util/flutter/notifications/local_notifs.dart
+++ b/lib/util/flutter/notifications/local_notifs.dart
@@ -18,6 +18,7 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:timezone/data/latest.dart' as tzdata;
 import 'package:timezone/timezone.dart' as tz;
 
+import '../../../entity/job_activity.dart';
 import '../../../entity/todo.dart';
 import 'desktop_scheduler.dart';
 import 'native_timezone.dart';
@@ -35,6 +36,7 @@ class LocalNotifs {
   final _fln = FlutterLocalNotificationsPlugin();
   DesktopNotifScheduler? _desktop;
   var _inited = false;
+  var _permissionGranted = true;
   var _iana = 'UTC';
   void Function(Map<String, String> payload)? onNotificationPayload;
 
@@ -88,7 +90,10 @@ class LocalNotifs {
             .resolvePlatformSpecificImplementation<
               AndroidFlutterLocalNotificationsPlugin
             >();
-        await android?.requestNotificationsPermission();
+        final granted = await android?.requestNotificationsPermission();
+        if (granted == false) {
+          _permissionGranted = false;
+        }
         // NOTE: If you later require exact alarms, add the manifest permission
         // and deep-link users to the exact-alarm settings screen.
       } else if (Platform.isIOS) {
@@ -96,13 +101,27 @@ class LocalNotifs {
             .resolvePlatformSpecificImplementation<
               IOSFlutterLocalNotificationsPlugin
             >();
-        await ios?.requestPermissions(alert: true, badge: true, sound: true);
+        final granted = await ios?.requestPermissions(
+          alert: true,
+          badge: true,
+          sound: true,
+        );
+        if (granted == false) {
+          _permissionGranted = false;
+        }
       } else if (Platform.isMacOS) {
         final macos = _fln
             .resolvePlatformSpecificImplementation<
               MacOSFlutterLocalNotificationsPlugin
             >();
-        await macos?.requestPermissions(alert: true, badge: true, sound: true);
+        final granted = await macos?.requestPermissions(
+          alert: true,
+          badge: true,
+          sound: true,
+        );
+        if (granted == false) {
+          _permissionGranted = false;
+        }
       }
 
       // ---- desktop in-app scheduler (Windows/Linux only) ----
@@ -134,8 +153,11 @@ class LocalNotifs {
     ),
   );
 
-  Future<void> schedule(Notif n) async {
+  Future<bool> schedule(Notif n) async {
     await init();
+    if (!_permissionGranted) {
+      return false;
+    }
 
     // Normalize: treat n.scheduledAtMillis as a local wall-clock instant.
     // We recreate a TZDateTime in tz.local to preserve wall-clock semantics
@@ -167,7 +189,7 @@ class LocalNotifs {
 
       // If after the grace and min-lead it's still in the past, skip.
       if (whenTz.isBefore(tz.TZDateTime.now(tz.local).add(_grace))) {
-        return;
+        return false;
       }
 
       await _fln.zonedSchedule(
@@ -183,8 +205,8 @@ class LocalNotifs {
     } else if (Platform.isWindows || Platform.isLinux) {
       // Enqueue into in-app scheduler (fires while app is open).
       // If way in the past (beyond grace), skip enqueue.
-      if (ms + _grace.inMilliseconds < nowMs) {
-        return;
+      if (target.millisecondsSinceEpoch + _grace.inMilliseconds < nowMs) {
+        return false;
       }
     }
 
@@ -196,9 +218,10 @@ class LocalNotifs {
         body: n.body,
         scheduledAtMillis: target.millisecondsSinceEpoch,
         payload: n.payload,
-        channel: Channel.todo(),
+        channel: n.channel,
       ),
     );
+    return true;
   }
 
   Future<void> cancel(int id) async {
@@ -214,25 +237,33 @@ class LocalNotifs {
   }
 
   /// Schedule from ToDo (store LOCAL → schedule in LOCAL tz).
-  Future<void> scheduleForToDo(ToDo todo) async {
+  Future<bool> scheduleForToDo(ToDo todo) async {
     final when = todo.remindAt;
     if (when == null) {
-      return;
+      return false;
     }
 
-    final n = Notif(
-      id: _idForToDo(todo.id),
-      title: 'Reminder',
-      body: todo.title,
-      // `when` is LOCAL; keep it local by passing its epoch straight through.
-      scheduledAtMillis: when.millisecondsSinceEpoch,
-      payload: {'type': 'todo', 'id': '${todo.id}'},
-      channel: Channel.todo(),
+    return schedule(
+      Notif.forToDo(todoId: todo.id, title: todo.title, remindAt: when),
     );
-    await schedule(n);
   }
 
+  Future<bool> scheduleForJobActivity(
+    JobActivity activity, {
+    required String jobSummary,
+  }) => schedule(
+    Notif.forJobActivity(
+      activityId: activity.id,
+      jobId: activity.jobId,
+      jobSummary: jobSummary,
+      startsAt: activity.start,
+    ),
+  );
+
   Future<void> cancelForToDo(int todoId) => cancel(_idForToDo(todoId));
+
+  Future<void> cancelForJobActivity(int activityId) =>
+      cancel(_idForJobActivity(activityId));
 
   /// Sync reminder state for a To-Do.
   /// Returns `false` when scheduling/canceling fails so callers can degrade
@@ -242,7 +273,7 @@ class LocalNotifs {
       if (todo.status != ToDoStatus.open || todo.remindAt == null) {
         await cancelForToDo(todo.id);
       } else {
-        await scheduleForToDo(todo);
+        return scheduleForToDo(todo);
       }
       return true;
     } catch (e, st) {
@@ -251,33 +282,50 @@ class LocalNotifs {
     }
   }
 
-  /// Optional: resync desktop scheduler from current open To-Dos.
-  /// Call this on app start or after a big data refresh.
+  Future<bool> syncForJobActivity(
+    JobActivity activity, {
+    required String jobSummary,
+  }) async {
+    try {
+      await cancelForJobActivity(activity.id);
+      return scheduleForJobActivity(activity, jobSummary: jobSummary);
+    } catch (e, st) {
+      debugPrint(
+        'Failed to sync reminder for job activity ${activity.id}: $e\n$st',
+      );
+      return false;
+    }
+  }
+
+  /// Resync reminders from current open To-Dos on app startup.
   Future<void> resyncFromToDos(Iterable<ToDo> todos) async {
     await init();
-    if (!Platform.isWindows && !Platform.isLinux) {
+    final pendingTodos = todos
+        .where((t) => t.remindAt != null && t.status == ToDoStatus.open)
+        .toList();
+
+    if (Platform.isWindows || Platform.isLinux) {
+      _desktop?.resync(
+        pendingTodos.map(
+          (todo) => Notif.forToDo(
+            todoId: todo.id,
+            title: todo.title,
+            remindAt: todo.remindAt!,
+          ),
+        ),
+      );
       return;
     }
 
-    final notifs = todos
-        .where((t) => t.remindAt != null && t.status == ToDoStatus.open)
-        .map(
-          (t) => Notif(
-            id: _idForToDo(t.id),
-            title: 'Reminder',
-            body: t.title,
-            scheduledAtMillis: t.remindAt!.millisecondsSinceEpoch,
-            payload: {'type': 'todo', 'id': '${t.id}'},
-            channel: Channel.todo(),
-          ),
-        );
-
-    _desktop?.resync(notifs);
+    for (final todo in pendingTodos) {
+      await scheduleForToDo(todo);
+    }
   }
 
   // ---- Helpers -------------------------------------------------------------
 
   int _idForToDo(int todoId) => 20_000_000 + todoId;
+  int _idForJobActivity(int activityId) => 30_000_000 + activityId;
 
   String? _encodePayload(Map<String, String>? p) {
     if (p == null || p.isEmpty) {

--- a/lib/util/flutter/notifications/notif.dart
+++ b/lib/util/flutter/notifications/notif.dart
@@ -21,6 +21,11 @@ class Channel {
     name: 'TODO_REMINDERS',
     description: 'Todo Reminders',
   );
+  factory Channel.job() => const Channel._(
+    id: 'HMB_NOTIF_JOB',
+    name: 'JOB_REMINDERS',
+    description: 'Schedule Reminders',
+  );
   const Channel._({
     required this.id,
     required this.name,
@@ -31,6 +36,8 @@ class Channel {
 /// A lightweight description of a local notification.
 @immutable
 class Notif {
+  static const jobActivityReminderLead = Duration(minutes: 30);
+
   final Channel channel;
   final int id;
   final String title;
@@ -50,4 +57,37 @@ class Notif {
     required this.channel,
     this.payload,
   });
+
+  factory Notif.forToDo({
+    required int todoId,
+    required String title,
+    required DateTime remindAt,
+  }) => Notif(
+    id: 20_000_000 + todoId,
+    title: 'Reminder',
+    body: title,
+    scheduledAtMillis: remindAt.millisecondsSinceEpoch,
+    payload: {'type': 'todo', 'id': '$todoId'},
+    channel: Channel.todo(),
+  );
+
+  factory Notif.forJobActivity({
+    required int activityId,
+    required int jobId,
+    required String jobSummary,
+    required DateTime startsAt,
+  }) => Notif(
+    id: 30_000_000 + activityId,
+    title: 'Upcoming job',
+    body: '$jobSummary starts soon',
+    scheduledAtMillis: startsAt
+        .subtract(jobActivityReminderLead)
+        .millisecondsSinceEpoch,
+    payload: {
+      'type': 'job_reminder',
+      'activityId': '$activityId',
+      'jobId': '$jobId',
+    },
+    channel: Channel.job(),
+  );
 }

--- a/test/dao/dao_job_activity_test.dart
+++ b/test/dao/dao_job_activity_test.dart
@@ -1,0 +1,42 @@
+import 'package:hmb/dao/dao.g.dart';
+import 'package:hmb/entity/entity.g.dart';
+import 'package:money2/money2.dart';
+import 'package:test/test.dart';
+
+import '../database/management/db_utility_test_helper.dart';
+import 'invoice/utility.dart';
+
+void main() {
+  setUp(() async {
+    await setupTestDb();
+  });
+
+  tearDown(() async {
+    await tearDownTestDb();
+  });
+
+  test('gets future job activities for reminder resync', () async {
+    final now = DateTime.now();
+    final job = await createJob(
+      now,
+      BillingType.timeAndMaterial,
+      hourlyRate: Money.fromInt(5000, isoCode: 'AUD'),
+    );
+    final past = JobActivity.forInsert(
+      jobId: job.id,
+      start: now.subtract(const Duration(hours: 2)),
+      end: now.subtract(const Duration(hours: 1)),
+    );
+    final future = JobActivity.forInsert(
+      jobId: job.id,
+      start: now.add(const Duration(hours: 2)),
+      end: now.add(const Duration(hours: 3)),
+    );
+    await DaoJobActivity().insert(past);
+    await DaoJobActivity().insert(future);
+
+    final activities = await DaoJobActivity().getStartingAfter(now);
+
+    expect(activities.map((activity) => activity.start), [future.start]);
+  });
+}

--- a/test/entity/todo_due_date_test.dart
+++ b/test/entity/todo_due_date_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/entity/todo.dart';
+
+void main() {
+  group('ToDo.withDueDate', () {
+    test('preserves reminder lead time when the new due date passes it', () {
+      final todo = ToDo.forInsert(
+        title: 'Call customer',
+        dueDate: DateTime(2026, 7, 10, 12),
+        remindAt: DateTime(2026, 7, 9, 8),
+      );
+
+      final updated = todo.withDueDate(DateTime(2026, 7, 8, 12));
+
+      expect(updated.dueDate, DateTime(2026, 7, 8, 12));
+      expect(updated.remindAt, DateTime(2026, 7, 7, 8));
+    });
+
+    test('leaves a reminder unchanged when it remains before the due date', () {
+      final reminder = DateTime(2026, 7, 9, 8);
+      final todo = ToDo.forInsert(
+        title: 'Call customer',
+        dueDate: DateTime(2026, 7, 10, 12),
+        remindAt: reminder,
+      );
+
+      final updated = todo.withDueDate(DateTime(2026, 7, 12, 12));
+
+      expect(updated.dueDate, DateTime(2026, 7, 12, 12));
+      expect(updated.remindAt, reminder);
+    });
+  });
+}

--- a/test/ui/crud/job/mini_job_dashboard_test.dart
+++ b/test/ui/crud/job/mini_job_dashboard_test.dart
@@ -1,6 +1,7 @@
 @Tags(['flutter'])
 library;
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hmb/dao/dao.g.dart';
 import 'package:hmb/entity/entity.g.dart';
@@ -47,6 +48,58 @@ void main() {
 
     expect(value.value, 2);
   });
+
+  testWidgets('estimate dashlet converts and opens with one prompt', (
+    tester,
+  ) async {
+    late Job job;
+    await tester.runAsync(() async {
+      job = await createJobWithCustomer(
+        billingType: BillingType.timeAndMaterial,
+        hourlyRate: Money.fromInt(5000, isoCode: 'AUD'),
+      );
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: MiniJobDashboard(job: job)),
+      ),
+    );
+    await _pumpUntilFound(tester, find.text('Estimate'));
+
+    await tester.tap(find.text('Estimate'));
+    await _pumpUntilFound(tester, find.text('Switch to Fixed Price'));
+
+    expect(find.text('Estimates Require Fixed Price'), findsOneWidget);
+
+    await tester.tap(find.text('Switch to Fixed Price'));
+    await _pumpUntilFound(tester, find.textContaining('Estimate Complete:'));
+
+    expect(find.text('Estimates Require Fixed Price'), findsNothing);
+    expect(find.text('Estimate Builder'), findsOneWidget);
+
+    await tester.runAsync(() async {
+      final updated = await DaoJob().getById(job.id);
+      expect(updated?.billingType, BillingType.fixedPrice);
+    });
+  });
+}
+
+Future<void> _pumpUntilFound(
+  WidgetTester tester,
+  Finder finder, {
+  int attempts = 40,
+}) async {
+  for (var i = 0; i < attempts; i++) {
+    await tester.pump();
+    if (finder.evaluate().isNotEmpty) {
+      return;
+    }
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 50)),
+    );
+  }
+  throw TestFailure('Timed out waiting for $finder');
 }
 
 Task _task(TaskStatus status) => Task.forInsert(

--- a/test/ui/dialog/message_template_dialog_test.dart
+++ b/test/ui/dialog/message_template_dialog_test.dart
@@ -1,0 +1,83 @@
+@Tags(['flutter'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/dao/dao_message_template.dart';
+import 'package:hmb/entity/message_template.dart';
+import 'package:hmb/ui/dialog/message_template_dialog.dart';
+import 'package:hmb/ui/dialog/source_context.dart';
+
+import '../../database/management/db_utility_test_helper.dart';
+
+void main() {
+  setUp(setupTestDb);
+  tearDown(tearDownTestDb);
+
+  Future<void> settleAsync(WidgetTester tester) async {
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 100)),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 350));
+  }
+
+  testWidgets('selected SMS template immediately replaces editor text', (
+    tester,
+  ) async {
+    await tester.runAsync(() async {
+      await DaoMessageTemplate().insert(
+        MessageTemplate.forInsert(
+          title: 'Feedback test template',
+          message: 'Please leave feedback',
+          messageType: MessageType.sms,
+        ),
+      );
+      await DaoMessageTemplate().insert(
+        MessageTemplate.forInsert(
+          title: 'Appointment test template',
+          message: 'Your appointment is tomorrow',
+          messageType: MessageType.sms,
+        ),
+      );
+      await DaoMessageTemplate().insert(
+        MessageTemplate.forInsert(
+          title: 'Email-only test template',
+          message: 'Email body',
+          messageType: MessageType.email,
+        ),
+      );
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MessageTemplateDialog(
+          sourceContext: SourceContext(),
+          messageType: MessageType.sms,
+        ),
+      ),
+    );
+    await settleAsync(tester);
+
+    await tester.tap(find.text('Select a Choose a template'));
+    await settleAsync(tester);
+
+    expect(find.text('Email-only test template'), findsNothing);
+    await tester.tap(find.text('Feedback test template'));
+    await settleAsync(tester);
+
+    var editor = tester.widget<TextFormField>(find.byType(TextFormField));
+    expect(editor.controller?.text, 'Please leave feedback');
+
+    await tester.tap(find.text('Feedback test template'));
+    await settleAsync(tester);
+    await tester.tap(find.text('Appointment test template'));
+    await tester.pump();
+
+    editor = tester.widget<TextFormField>(find.byType(TextFormField));
+    expect(editor.controller?.text, 'Your appointment is tomorrow');
+
+    await tester.pumpWidget(const SizedBox());
+    await tester.pump();
+  });
+}

--- a/test/util/measurement_type_test.dart
+++ b/test/util/measurement_type_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/util/dart/measurement_type.dart';
+import 'package:hmb/util/dart/units.dart';
+
+void main() {
+  group('area measurement defaults', () {
+    test('uses square millimetres for metric dimensions', () {
+      expect(MeasurementType.area.defaultMetric, same(Units.mm2));
+    });
+
+    test('uses square feet for imperial dimensions', () {
+      expect(MeasurementType.area.defaultImperial, same(Units.ft2));
+    });
+  });
+}

--- a/test/util/notification_plan_test.dart
+++ b/test/util/notification_plan_test.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:hmb/util/flutter/notifications/notif.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('todo notification uses a stable id and payload', () {
+    final remindAt = DateTime(2026, 7, 14, 9);
+
+    final notification = Notif.forToDo(
+      todoId: 42,
+      title: 'Order materials',
+      remindAt: remindAt,
+    );
+
+    expect(notification.id, 20_000_042);
+    expect(notification.body, 'Order materials');
+    expect(notification.scheduledAtMillis, remindAt.millisecondsSinceEpoch);
+    expect(notification.payload, {'type': 'todo', 'id': '42'});
+    expect(notification.channel.id, 'HMB_NOTIF_TODO');
+  });
+
+  test('job notification is scheduled thirty minutes before its start', () {
+    final startsAt = DateTime(2026, 7, 14, 9);
+
+    final notification = Notif.forJobActivity(
+      activityId: 7,
+      jobId: 12,
+      jobSummary: 'Repair leaking tap',
+      startsAt: startsAt,
+    );
+
+    expect(notification.id, 30_000_007);
+    expect(
+      DateTime.fromMillisecondsSinceEpoch(notification.scheduledAtMillis),
+      DateTime(2026, 7, 14, 8, 30),
+    );
+    expect(notification.payload?['jobId'], '12');
+    expect(notification.channel.id, 'HMB_NOTIF_JOB');
+  });
+
+  test('Android declares scheduled notification receivers', () {
+    final manifest = File(
+      'android/app/src/main/AndroidManifest.xml',
+    ).readAsStringSync();
+
+    expect(manifest, contains('android.permission.RECEIVE_BOOT_COMPLETED'));
+    expect(manifest, contains('ScheduledNotificationReceiver'));
+    expect(manifest, contains('ScheduledNotificationBootReceiver'));
+  });
+}


### PR DESCRIPTION
## Summary

- route the Estimate dashlet directly to the estimate builder
- keep the fixed-price conversion prompt in one place
- defer the prompt until the estimate screen has rendered its first frame
- add a regression test covering conversion and one-click estimator entry

## Root cause

The fixed-price guard existed in both the dashlet and the estimate screen. The
duplicated asynchronous flow could stop navigation after conversion and prompt
again on subsequent taps. The estimate screen's copy of the guard also tried to
open a dialog during asynchronous state initialization before inherited widgets
were safe to access.

## User impact

For a Time and Materials job, tapping Estimate now opens the estimator and asks
once to switch the job to Fixed Price. Accepting the prompt persists the change
and continues initialization without another tap.

## Validation

- `flutter test test/ui/crud/job/mini_job_dashboard_test.dart`
- `flutter analyze lib/ui/crud/job/estimator/edit_job_estimate_screen.dart lib/ui/crud/job/mini_job_dashboard.dart test/ui/crud/job/mini_job_dashboard_test.dart`
- `git diff --check`

Fixes #566
