### PR TITLE
#558 Guard job deletion

### DIFF
--- a/lib/ui/crud/base_full_screen/list_entity_screen.dart
+++ b/lib/ui/crud/base_full_screen/list_entity_screen.dart
@@ -42,6 +42,7 @@ class EntityListScreen<T extends Entity<T>> extends StatefulWidget {
   final Widget Function(T entity) listCard;
   final Future<T?> Function()? onAdd;
   final Future<bool> Function(T entity)? onDelete;
+  final Future<bool> Function(T entity, BuildContext context)? confirmDelete;
   final Widget Function(T? entity) onEdit;
   final Future<Color> Function(T entity)? background;
   final double cardHeight;
@@ -93,6 +94,7 @@ class EntityListScreen<T extends Entity<T>> extends StatefulWidget {
     /// deleting the entity.
     /// Return true if the delete occurred
     this.onDelete,
+    this.confirmDelete,
     this.cardHeight = 300,
     this.background,
     Future<List<T>> Function(String? filter)? fetchList,
@@ -384,6 +386,13 @@ class EntityListScreenState<T extends Entity<T>>
   );
 
   Future<void> _confirmDelete(T entity) async {
+    if (widget.confirmDelete != null) {
+      final confirmed = await widget.confirmDelete!(entity, context);
+      if (confirmed) {
+        await _delete(entity);
+      }
+      return;
+    }
     await showConfirmDeleteDialog(
       context: context,
       question:

--- a/lib/ui/crud/job/list_job_screen.dart
+++ b/lib/ui/crud/job/list_job_screen.dart
@@ -16,10 +16,11 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
-import '../../../dao/dao_job.dart';
+import '../../../dao/dao.g.dart';
 import '../../../entity/flutter_extensions/job_status_ex.dart';
 import '../../../entity/job.dart';
 import '../../../entity/job_status_stage.dart';
+import '../../../util/dart/format.dart';
 import '../../widgets/icons/hmb_copy_icon.dart';
 import '../../widgets/layout/layout.g.dart';
 import '../../widgets/select/select.g.dart';
@@ -161,6 +162,7 @@ class _JobListScreenState extends State<JobListScreen> {
               buildActionItems: _buildActionItems,
               canEdit: (job) => !job.isStock,
               canDelete: (job) => !job.isStock,
+              confirmDelete: _confirmJobDelete,
             ),
           ),
         ],
@@ -190,6 +192,9 @@ class _JobListScreenState extends State<JobListScreen> {
     }
     return selected;
   }
+
+  Future<bool> _confirmJobDelete(Job job, BuildContext context) =>
+      confirmJobDelete(job, context);
 
   Widget _buildFilterSheet(void Function() onChange) => HMBColumn(
     children: [
@@ -278,6 +283,80 @@ class _JobListScreenState extends State<JobListScreen> {
     }
   }
 }
+
+Future<bool> confirmJobDelete(Job job, BuildContext context) async {
+  final invoiceCount = await DaoInvoice().count(
+    where: 'job_id = ?',
+    whereArgs: [job.id],
+  );
+  if (invoiceCount > 0) {
+    if (context.mounted) {
+      HMBToast.error(
+        'Job "${job.summary}" cannot be deleted because it has '
+        '$invoiceCount invoice${invoiceCount == 1 ? '' : 's'}.',
+      );
+    }
+    return false;
+  }
+
+  final customer = await DaoCustomer().getByJob(job.id);
+  if (!context.mounted) {
+    return false;
+  }
+  final firstConfirmed = await _showJobDeleteConfirmation(
+    context,
+    title: 'Delete Job',
+    message:
+        'Delete "${job.summary}" for '
+        '"${customer?.name ?? 'Unknown customer'}"?',
+  );
+  if (!firstConfirmed) {
+    return false;
+  }
+
+  final entries = await DaoTimeEntry().getByJob(job.id);
+  if (entries.isEmpty || !context.mounted) {
+    return entries.isEmpty;
+  }
+  final total = entries.fold(
+    Duration.zero,
+    (duration, entry) => duration + entry.duration,
+  );
+  return _showJobDeleteConfirmation(
+    context,
+    title: 'Delete Logged Time?',
+    message:
+        'This job has ${formatDuration(total)} logged across '
+        '${entries.length} time entr${entries.length == 1 ? 'y' : 'ies'}. '
+        'Delete the job and this time?',
+  );
+}
+
+Future<bool> _showJobDeleteConfirmation(
+  BuildContext context, {
+  required String title,
+  required String message,
+}) async =>
+    await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(title),
+        content: Text(message),
+        actions: [
+          HMBButton(
+            label: 'Cancel',
+            hint: "Don't delete this job",
+            onPressed: () => Navigator.pop(dialogContext, false),
+          ),
+          HMBButton(
+            label: 'Delete',
+            hint: 'Delete this job',
+            onPressed: () => Navigator.pop(dialogContext, true),
+          ),
+        ],
+      ),
+    ) ??
+    false;
 
 // class FilterState extends JuneState {
 //   var _showOnHoldAndFinalised = false;

--- a/test/ui/crud/job/list_job_screen_delete_test.dart
+++ b/test/ui/crud/job/list_job_screen_delete_test.dart
@@ -1,0 +1,155 @@
+@Tags(['flutter'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/dao/dao.g.dart';
+import 'package:hmb/entity/entity.g.dart';
+import 'package:hmb/ui/crud/job/list_job_screen.dart';
+import 'package:hmb/util/dart/local_date.dart';
+import 'package:hmb/util/dart/money_ex.dart';
+import 'package:toastification/toastification.dart';
+
+import '../../../database/management/db_utility_test_helper.dart';
+import '../../ui_test_helpers.dart';
+
+void main() {
+  setUp(() async {
+    await setupTestDb();
+  });
+
+  tearDown(() async {
+    await tearDownTestDb();
+  });
+
+  testWidgets('job deletion identifies the customer and job', (tester) async {
+    late Job job;
+    late Customer customer;
+    await tester.runAsync(() async {
+      job = await createJobWithCustomer(
+        billingType: BillingType.timeAndMaterial,
+        hourlyRate: MoneyEx.zero,
+        summary: 'Repair verandah',
+      );
+      customer = (await DaoCustomer().getByJob(job.id))!;
+    });
+
+    final result = await _pumpDeleteHarness(tester, job);
+    await tester.tap(find.text('Start deletion'));
+    await _pumpUntilFound(tester, find.text('Delete Job'));
+
+    expect(find.text('Delete Job'), findsOneWidget);
+    expect(
+      find.text('Delete "Repair verandah" for "${customer.name}"?'),
+      findsOneWidget,
+    );
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Cancel'));
+    await tester.pump();
+    expect(await tester.runAsync(result), isFalse);
+  });
+
+  testWidgets('job deletion requires confirmation for logged time', (
+    tester,
+  ) async {
+    late Job job;
+    await tester.runAsync(() async {
+      job = await createJobWithCustomer(
+        billingType: BillingType.timeAndMaterial,
+        hourlyRate: MoneyEx.zero,
+      );
+      final taskId = await DaoTask().insert(
+        Task.forInsert(
+          jobId: job.id,
+          name: 'Repair',
+          description: '',
+          status: TaskStatus.inProgress,
+        ),
+      );
+      await DaoTimeEntry().insert(
+        TimeEntry.forInsert(
+          taskId: taskId,
+          startTime: DateTime(2026, 8, 10, 9),
+          endTime: DateTime(2026, 8, 10, 10, 30),
+        ),
+      );
+    });
+
+    final result = await _pumpDeleteHarness(tester, job);
+    await tester.tap(find.text('Start deletion'));
+    await _pumpUntilFound(tester, find.text('Delete Job'));
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Delete'));
+    await _pumpUntilFound(tester, find.text('Delete Logged Time?'));
+
+    expect(find.text('Delete Logged Time?'), findsOneWidget);
+    expect(
+      find.textContaining('1h 30m logged across 1 time entry'),
+      findsOneWidget,
+    );
+    await tester.tap(find.widgetWithText(ElevatedButton, 'Cancel'));
+    await tester.pump();
+    expect(await tester.runAsync(result), isFalse);
+  });
+
+  testWidgets('invoiced jobs cannot enter the deletion flow', (tester) async {
+    late Job job;
+    await tester.runAsync(() async {
+      job = await createJobWithCustomer(
+        billingType: BillingType.timeAndMaterial,
+        hourlyRate: MoneyEx.zero,
+      );
+      await DaoInvoice().insert(
+        Invoice.forInsert(
+          jobId: job.id,
+          dueDate: LocalDate.today(),
+          totalAmount: MoneyEx.zero,
+          billingContactId: job.billingContactId,
+        ),
+      );
+    });
+
+    final result = await _pumpDeleteHarness(tester, job);
+    await tester.tap(find.text('Start deletion'));
+    expect(await tester.runAsync(result), isFalse);
+    await tester.pump();
+
+    expect(find.text('Delete Job'), findsNothing);
+    expect(await tester.runAsync(() => DaoJob().getById(job.id)), isNotNull);
+    toastification.dismissAll();
+    await tester.pump(const Duration(seconds: 1));
+  });
+}
+
+Future<Future<bool> Function()> _pumpDeleteHarness(
+  WidgetTester tester,
+  Job job,
+) async {
+  Future<bool>? result;
+  await tester.pumpWidget(
+    ToastificationWrapper(
+      child: MaterialApp(
+        home: Scaffold(
+          body: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () => result = confirmJobDelete(job, context),
+              child: const Text('Start deletion'),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  return () => result!;
+}
+
+Future<void> _pumpUntilFound(WidgetTester tester, Finder finder) async {
+  for (var attempt = 0; attempt < 20; attempt++) {
+    await tester.pump();
+    if (finder.evaluate().isNotEmpty) {
+      return;
+    }
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 50)),
+    );
+  }
+  fail('Expected UI did not appear: $finder');
+}


### PR DESCRIPTION
## Summary
- show the customer and job name before deleting a job
- block deletion when the job has invoices
- require a second confirmation showing total logged time
- add focused widget coverage for all three paths

## Validation
- `flutter analyze lib/ui/crud/job/list_job_screen.dart test/ui/crud/job/list_job_screen_delete_test.dart`
- `flutter test test/ui/crud/job/list_job_screen_delete_test.dart`

Fixes #558