### PR TITLE
#559 Reset recent job scroll position

### DIFF
--- a/lib/ui/crud/base_full_screen/list_entity_screen.dart
+++ b/lib/ui/crud/base_full_screen/list_entity_screen.dart
@@ -67,6 +67,7 @@ class EntityListScreen<T extends Entity<T>> extends StatefulWidget {
   /// to make back navigation clear.
   final bool showBackButton;
   final Widget? emptyBody;
+  final bool scrollToTopOnReturn;
 
   EntityListScreen({
     required this.entityNamePlural,
@@ -108,6 +109,7 @@ class EntityListScreen<T extends Entity<T>> extends StatefulWidget {
     this.buildActionItems,
     this.editButtonKey,
     this.emptyBody,
+    this.scrollToTopOnReturn = false,
   }) {
     _fetchList = fetchList ?? (_) => dao.getAll();
   }
@@ -403,7 +405,14 @@ class EntityListScreenState<T extends Entity<T>>
 
   @override
   void didPopNext() {
-    unawaited(refresh());
+    unawaited(_refreshAfterPop());
+  }
+
+  Future<void> _refreshAfterPop() async {
+    await refresh();
+    if (widget.scrollToTopOnReturn && _scrollController.hasClients) {
+      _scrollController.jumpTo(0);
+    }
   }
 
   Future<void> _delete(T entity) async {

--- a/lib/ui/crud/job/list_job_screen.dart
+++ b/lib/ui/crud/job/list_job_screen.dart
@@ -161,6 +161,7 @@ class _JobListScreenState extends State<JobListScreen> {
               buildActionItems: _buildActionItems,
               canEdit: (job) => !job.isStock,
               canDelete: (job) => !job.isStock,
+              scrollToTopOnReturn: true,
             ),
           ),
         ],

--- a/test/ui/crud/job/list_job_screen_scroll_test.dart
+++ b/test/ui/crud/job/list_job_screen_scroll_test.dart
@@ -1,0 +1,98 @@
+@Tags(['flutter'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/entity/entity.g.dart';
+import 'package:hmb/ui/crud/base_full_screen/list_entity_screen.dart';
+import 'package:hmb/ui/crud/job/list_job_screen.dart';
+import 'package:hmb/util/dart/money_ex.dart';
+
+import '../../../database/management/db_utility_test_helper.dart';
+import '../../ui_test_helpers.dart';
+
+void main() {
+  setUp(() async {
+    FlutterSecureStorage.setMockInitialValues({});
+    await setupTestDb();
+  });
+
+  tearDown(() async {
+    await tearDownTestDb();
+  });
+
+  testWidgets('returning to recent jobs resets the scroll position', (
+    tester,
+  ) async {
+    await tester.runAsync(() async {
+      for (var index = 0; index < 4; index++) {
+        await createJobWithCustomer(
+          billingType: BillingType.timeAndMaterial,
+          hourlyRate: MoneyEx.zero,
+          summary: 'Recent job $index',
+        );
+      }
+    });
+
+    await tester.pumpWidget(
+      const MaterialApp(home: Scaffold(body: JobListScreen())),
+    );
+    await _pumpUntilJobsLoad(tester);
+
+    final listFinder = find.byType(ListView);
+    await tester.drag(listFinder, const Offset(0, -600));
+    await tester.pump(const Duration(seconds: 1));
+    final list = tester.widget<ListView>(listFinder);
+    expect(list.controller!.offset, greaterThan(0));
+
+    tester
+        .state<EntityListScreenState<Job>>(find.byType(EntityListScreen<Job>))
+        .didPopNext();
+    await _pumpUntilScrolledToTop(tester, list.controller!);
+
+    expect(list.controller!.offset, 0);
+    await _disposeHarness(tester);
+  });
+}
+
+Future<void> _pumpUntilJobsLoad(WidgetTester tester) async {
+  for (var attempt = 0; attempt < 30; attempt++) {
+    await tester.pump();
+    if (find.text('Recent job 3').evaluate().isNotEmpty) {
+      await tester.runAsync(
+        () => Future<void>.delayed(const Duration(milliseconds: 300)),
+      );
+      await tester.pump();
+      return;
+    }
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 50)),
+    );
+  }
+  fail('Job list did not load.');
+}
+
+Future<void> _pumpUntilScrolledToTop(
+  WidgetTester tester,
+  ScrollController controller,
+) async {
+  for (var attempt = 0; attempt < 30; attempt++) {
+    await tester.pump();
+    if (controller.offset == 0) {
+      return;
+    }
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 50)),
+    );
+  }
+  fail('Job list did not reset its scroll position.');
+}
+
+Future<void> _disposeHarness(WidgetTester tester) async {
+  await tester.pumpWidget(const SizedBox.shrink());
+  await tester.runAsync(
+    () => Future<void>.delayed(const Duration(milliseconds: 100)),
+  );
+  await tester.pump();
+}


### PR DESCRIPTION
## Summary
- optionally reset an entity list to the top after returning from a child route
- enable that behaviour for the recently accessed jobs list
- add a focused widget test covering the return-and-reset flow

## Validation
- `flutter analyze lib/ui/crud/base_full_screen/list_entity_screen.dart lib/ui/crud/job/list_job_screen.dart test/ui/crud/job/list_job_screen_scroll_test.dart`
- `flutter test test/ui/crud/job/list_job_screen_scroll_test.dart`

Fixes #559