### PR TITLE
Fix compact job wizard actions

### DIFF
--- a/lib/ui/crud/customer/customer_paste_panel.dart
+++ b/lib/ui/crud/customer/customer_paste_panel.dart
@@ -18,6 +18,7 @@ class CustomerPastePanel extends StatefulWidget {
   final bool extractAvailable;
   final String? helperText;
   final String extractLabel;
+  final String skipLabel;
 
   const CustomerPastePanel({
     required this.onExtract,
@@ -30,6 +31,7 @@ class CustomerPastePanel extends StatefulWidget {
     this.extractAvailable = true,
     this.helperText,
     this.extractLabel = 'Extract',
+    this.skipLabel = 'Skip extraction',
   });
 
   @override
@@ -118,7 +120,7 @@ class _CustomerPastePanelState extends DeferredState<CustomerPastePanel> {
           if (widget.onSkip != null)
             HMBButton(
               onPressed: widget.onSkip!,
-              label: 'Skip extraction',
+              label: widget.skipLabel,
               hint: 'Continue without extracting details from a message',
               enabled: !widget.isExtracting,
             ),

--- a/lib/ui/crud/job/job_creator.dart
+++ b/lib/ui/crud/job/job_creator.dart
@@ -889,9 +889,9 @@ class _ExtractAndMatchStep extends WizardStep {
             initialMessage: state._pasteMessage,
             onChanged: (value) => state._pasteMessage = value,
             helperText:
-                'Paste a customer message to fill the wizard using AI, or skip '
-                'extraction and enter the details manually.',
-            extractLabel: 'Extract using AI',
+                'Paste a customer message to extract the job details using AI, '
+                'or skip extraction and enter the job details manually',
+            skipLabel: 'Skip',
             extractAvailable: state._aiConfigured,
             onExtractUnavailable: state._showAiRequiredMessage,
             onSkip: () async {

--- a/test/ui/crud/customer/customer_paste_panel_test.dart
+++ b/test/ui/crud/customer/customer_paste_panel_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/ui/crud/customer/customer_paste_panel.dart';
+
+void main() {
+  testWidgets('mobile actions use short labels and remain side by side', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(360, 640));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    const helperText =
+        'Paste a customer message to extract the job details using AI, or skip '
+        'extraction and enter the job details manually';
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: CustomerPastePanel(
+            initialMessage: '',
+            helperText: helperText,
+            skipLabel: 'Skip',
+            onSkip: () {},
+            onExtract: (_) {},
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text(helperText), findsOneWidget);
+    expect(find.text('Skip'), findsOneWidget);
+    expect(find.text('Extract'), findsOneWidget);
+
+    final skipCenter = tester.getCenter(find.text('Skip'));
+    final extractCenter = tester.getCenter(find.text('Extract'));
+    expect(skipCenter.dy, extractCenter.dy);
+    expect(skipCenter.dx, lessThan(extractCenter.dx));
+  });
+}


### PR DESCRIPTION
## Summary
- rename the mobile wizard actions to `Skip` and `Extract`
- use the requested extraction helper text
- keep the actions side-by-side at a 360px mobile width

## Validation
- `flutter analyze lib/ui/crud/customer/customer_paste_panel.dart lib/ui/crud/job/job_creator.dart test/ui/crud/customer/customer_paste_panel_test.dart`
- `flutter test test/ui/crud/customer/customer_paste_panel_test.dart`

Fixes #568