### PR TITLE
Allow quote cards to grow without clipping

### DIFF
--- a/lib/ui/crud/base_full_screen/list_entity_screen.dart
+++ b/lib/ui/crud/base_full_screen/list_entity_screen.dart
@@ -45,7 +45,10 @@ class EntityListScreen<T extends Entity<T>> extends StatefulWidget {
   final Future<bool> Function(T entity, BuildContext context)? confirmDelete;
   final Widget Function(T? entity) onEdit;
   final Future<Color> Function(T entity)? background;
-  final double cardHeight;
+
+  /// A fixed extent for uniformly sized cards. Leave null when card content
+  /// can grow, wrap, or expose a varying set of actions.
+  final double? cardHeight;
 
   /// Widgets to place in the cards action menu
   /// which also contains the delete button.

--- a/lib/ui/quoting/list_quote_screen.dart
+++ b/lib/ui/quoting/list_quote_screen.dart
@@ -158,7 +158,7 @@ class _QuoteListScreenState extends State<QuoteListScreen> {
     onEdit: (q) => QuoteDetailsScreen(quoteId: q!.id),
     background: (_) async => Colors.transparent,
     listCard: _buildQuoteCard,
-    cardHeight: 460,
+    cardHeight: null,
     filterSheetBuilder: widget.job == null ? _buildFilterSheet : null,
     isFilterActive: () =>
         widget.job == null &&

--- a/test/ui/crud/base_full_screen/list_entity_screen_height_test.dart
+++ b/test/ui/crud/base_full_screen/list_entity_screen_height_test.dart
@@ -1,0 +1,71 @@
+@Tags(['flutter'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/dao/dao.g.dart';
+import 'package:hmb/entity/entity.g.dart';
+import 'package:hmb/ui/crud/base_full_screen/list_entity_screen.dart';
+import 'package:hmb/util/dart/money_ex.dart';
+
+import '../../../database/management/db_utility_test_helper.dart';
+
+void main() {
+  setUp(() async {
+    FlutterSecureStorage.setMockInitialValues({});
+    await setupTestDb();
+  });
+
+  tearDown(tearDownTestDb);
+
+  testWidgets('variable height cards do not clip their actions', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(800, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    final now = DateTime.now();
+    final customer = Customer(
+      id: 1,
+      name: 'Variable height customer',
+      description: null,
+      disbarred: false,
+      customerType: CustomerType.residential,
+      hourlyRate: MoneyEx.zero,
+      billingContactId: null,
+      createdDate: now,
+      modifiedDate: now,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: EntityListScreen<Customer>(
+          entityNamePlural: 'Customers',
+          entityNameSingular: 'Customer',
+          dao: DaoCustomer(),
+          fetchList: (_) async => [customer],
+          listCardTitle: (_) => const Text('Variable card'),
+          listCard: (_) => const SizedBox(
+            height: 520,
+            child: Align(
+              alignment: Alignment.bottomCenter,
+              child: Text('Variable height action'),
+            ),
+          ),
+          onEdit: (_) => const SizedBox.shrink(),
+          canAdd: false,
+          canEdit: (_) => false,
+          canDelete: (_) => false,
+          cardHeight: null,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final list = tester.widget<ListView>(find.byType(ListView));
+    expect(list.itemExtent, isNull);
+    expect(find.text('Variable height action'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- allow entity lists to opt out of a fixed item extent
- let quote cards use their natural height as content and action rows vary
- cover a card taller than the previous 460px quote extent

## Validation
- `flutter analyze lib/ui/crud/base_full_screen/list_entity_screen.dart lib/ui/quoting/list_quote_screen.dart test/ui/crud/base_full_screen/list_entity_screen_height_test.dart`
- `flutter test test/ui/crud/base_full_screen/list_entity_screen_height_test.dart`

Fixes #574