### PR TITLE
Raise quotes from completed estimates

### DIFF
--- a/lib/ui/crud/job/estimator/edit_job_estimate_screen.dart
+++ b/lib/ui/crud/job/estimator/edit_job_estimate_screen.dart
@@ -31,6 +31,8 @@ import '../../../../util/dart/money_ex.dart';
 import '../../../../util/dart/units.dart';
 import '../../../dialog/hmb_comfirm_delete_dialog.dart';
 import '../../../dialog/hmb_dialog.dart';
+import '../../../invoicing/dialog_select_tasks.dart';
+import '../../../widgets/blocking_ui.dart';
 import '../../../widgets/hmb_button.dart';
 import '../../../widgets/hmb_search.dart';
 import '../../../widgets/hmb_toast.dart';
@@ -327,7 +329,20 @@ class _JobEstimateBuilderScreenState
       child: HMBColumn(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('Estimate Complete: ${_estimateComplete ? 'Yes' : 'No'}'),
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Estimate Complete: ${_estimateComplete ? 'Yes' : 'No'}',
+                ),
+              ),
+              HMBButton.small(
+                label: 'Raise Quote',
+                hint: 'Create a fixed price quote from this estimate',
+                onPressed: () => unawaited(_raiseQuote()),
+              ),
+            ],
+          ),
           Text('Labour: $_totalLabourCost'),
           Text('Materials: $_totalMaterialsCost'),
           Row(
@@ -344,6 +359,45 @@ class _JobEstimateBuilderScreenState
         ],
       ),
     );
+  }
+
+  Future<void> _raiseQuote() async {
+    if (!_estimateComplete) {
+      HMBToast.error(
+        'Mark every task estimate as complete before raising a quote.',
+        acknowledgmentRequired: true,
+      );
+      return;
+    }
+
+    final options = await selectTaskToQuote(
+      context: context,
+      job: widget.job,
+      title: 'Tasks for Quote',
+    );
+    if (options == null) {
+      return;
+    }
+    if (!options.billBookingFee && options.selectedTaskIds.isEmpty) {
+      HMBToast.error(
+        'You must select a task or the booking fee',
+        acknowledgmentRequired: true,
+      );
+      return;
+    }
+
+    try {
+      await BlockingUI().runAndWait(
+        label: 'Creating Quote',
+        () => DaoQuote().create(widget.job, options),
+      );
+      HMBToast.info('Quote created successfully.');
+    } catch (e) {
+      HMBToast.error(
+        'Failed to create quote: $e',
+        acknowledgmentRequired: true,
+      );
+    }
   }
 
   Future<void> _saveEstimateMargin(Percentage parsed) async {

--- a/test/ui/crud/job/estimator/edit_job_estimate_screen_test.dart
+++ b/test/ui/crud/job/estimator/edit_job_estimate_screen_test.dart
@@ -1,0 +1,81 @@
+@Tags(['flutter'])
+library;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hmb/dao/dao.g.dart';
+import 'package:hmb/entity/entity.g.dart';
+import 'package:hmb/ui/crud/job/estimator/edit_job_estimate_screen.dart';
+import 'package:hmb/util/dart/money_ex.dart';
+import 'package:toastification/toastification.dart';
+
+import '../../../../database/management/db_utility_test_helper.dart';
+import '../../../ui_test_helpers.dart';
+
+void main() {
+  setUp(() async {
+    FlutterSecureStorage.setMockInitialValues({});
+    await setupTestDb();
+  });
+
+  tearDown(tearDownTestDb);
+
+  testWidgets('raising a quote requires every estimate to be complete', (
+    tester,
+  ) async {
+    late Job job;
+    await tester.runAsync(() async {
+      job = await createJobWithCustomer(
+        billingType: BillingType.fixedPrice,
+        hourlyRate: MoneyEx.zero,
+        summary: 'Incomplete estimate',
+      );
+      await DaoTask().insert(
+        Task.forInsert(
+          jobId: job.id,
+          name: 'Still estimating',
+          description: '',
+          status: TaskStatus.awaitingApproval,
+        ),
+      );
+    });
+
+    await tester.pumpWidget(
+      ToastificationWrapper(
+        child: MaterialApp(home: JobEstimateBuilderScreen(job: job)),
+      ),
+    );
+    await _pumpUntilFound(tester, find.text('Raise Quote'));
+
+    expect(find.text('Estimate Complete: No'), findsOneWidget);
+    await tester.tap(find.text('Raise Quote'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(
+      find.textContaining(
+        'Mark every task estimate as complete',
+        skipOffstage: false,
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Tasks for Quote'), findsNothing);
+    toastification.dismissAll();
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump(const Duration(seconds: 1));
+  });
+}
+
+Future<void> _pumpUntilFound(WidgetTester tester, Finder finder) async {
+  for (var attempt = 0; attempt < 40; attempt++) {
+    await tester.pump();
+    if (finder.evaluate().isNotEmpty) {
+      return;
+    }
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 50)),
+    );
+  }
+  fail('Timed out waiting for $finder');
+}


### PR DESCRIPTION
## Summary
- add a `Raise Quote` action to the estimate totals panel
- require every non-withdrawn task estimate to be complete before proceeding
- reuse the existing task-selection and quote-creation workflow under BlockingUI
- tell the user to complete estimates when the gate is not met

## Validation
- `flutter analyze lib/ui/crud/job/estimator/edit_job_estimate_screen.dart test/ui/crud/job/estimator/edit_job_estimate_screen_test.dart`
- `flutter test test/ui/crud/job/estimator/edit_job_estimate_screen_test.dart`

Fixes #573