### PR TITLE
Show shopping and packing counts in reminders

### DIFF
--- a/lib/dao/dao_task_item.dart
+++ b/lib/dao/dao_task_item.dart
@@ -334,6 +334,17 @@ SELECT ti.*
     return toList(await db.rawQuery(sql, params));
   }
 
+  /// Counts the outstanding items shown for a scheduled job reminder.
+  Future<({int shopping, int packing})> getReminderCounts(Job job) async {
+    final shopping = await getShoppingItems(jobs: [job]);
+    final packing = await getPackingItems(
+      jobs: [job],
+      showPreScheduledJobs: false,
+      showPreApprovedTask: false,
+    );
+    return (shopping: shopping.length, packing: packing.length);
+  }
+
   /// Calculate charge
   Money calculateCharge({
     required TaskItemType itemType,

--- a/lib/ui/nav/boot_strapper.dart
+++ b/lib/ui/nav/boot_strapper.dart
@@ -181,9 +181,12 @@ class BootStrapper {
     for (final activity in activities) {
       final job = await DaoJob().getById(activity.jobId);
       if (job != null) {
+        final counts = await DaoTaskItem().getReminderCounts(job);
         await LocalNotifs().syncForJobActivity(
           activity,
           jobSummary: job.summary,
+          shoppingCount: counts.shopping,
+          packingCount: counts.packing,
         );
       }
     }

--- a/lib/ui/scheduling/schedule_helper.dart
+++ b/lib/ui/scheduling/schedule_helper.dart
@@ -14,7 +14,7 @@
 import 'package:calendar_view/calendar_view.dart';
 import 'package:flutter/material.dart';
 
-import '../../dao/dao_job_activity.dart';
+import '../../dao/dao.g.dart';
 import '../../util/dart/format.dart';
 import '../../util/dart/local_date.dart';
 import '../../util/flutter/notifications/local_notifs.dart';
@@ -134,9 +134,12 @@ mixin ScheduleHelper {
   }
 
   Future<void> _syncActivityReminder(JobActivityEx activity) async {
+    final counts = await DaoTaskItem().getReminderCounts(activity.job);
     final synced = await LocalNotifs().syncForJobActivity(
       activity.jobActivity,
       jobSummary: activity.job.summary,
+      shoppingCount: counts.shopping,
+      packingCount: counts.packing,
     );
     if (!synced) {
       HMBToast.info(

--- a/lib/util/flutter/notifications/local_notifs.dart
+++ b/lib/util/flutter/notifications/local_notifs.dart
@@ -251,11 +251,15 @@ class LocalNotifs {
   Future<bool> scheduleForJobActivity(
     JobActivity activity, {
     required String jobSummary,
+    required int shoppingCount,
+    required int packingCount,
   }) => schedule(
     Notif.forJobActivity(
       activityId: activity.id,
       jobId: activity.jobId,
       jobSummary: jobSummary,
+      shoppingCount: shoppingCount,
+      packingCount: packingCount,
       startsAt: activity.start,
     ),
   );
@@ -285,10 +289,17 @@ class LocalNotifs {
   Future<bool> syncForJobActivity(
     JobActivity activity, {
     required String jobSummary,
+    required int shoppingCount,
+    required int packingCount,
   }) async {
     try {
       await cancelForJobActivity(activity.id);
-      return scheduleForJobActivity(activity, jobSummary: jobSummary);
+      return scheduleForJobActivity(
+        activity,
+        jobSummary: jobSummary,
+        shoppingCount: shoppingCount,
+        packingCount: packingCount,
+      );
     } catch (e, st) {
       debugPrint(
         'Failed to sync reminder for job activity ${activity.id}: $e\n$st',

--- a/lib/util/flutter/notifications/notif.dart
+++ b/lib/util/flutter/notifications/notif.dart
@@ -75,11 +75,15 @@ class Notif {
     required int activityId,
     required int jobId,
     required String jobSummary,
+    required int shoppingCount,
+    required int packingCount,
     required DateTime startsAt,
   }) => Notif(
     id: 30_000_000 + activityId,
     title: 'Upcoming job',
-    body: '$jobSummary starts soon',
+    body:
+        '$jobSummary starts soon\n'
+        'Shopping: $shoppingCount • Packing: $packingCount',
     scheduledAtMillis: startsAt
         .subtract(jobActivityReminderLead)
         .millisecondsSinceEpoch,

--- a/test/dao/dao_task_item_test.dart
+++ b/test/dao/dao_task_item_test.dart
@@ -76,6 +76,27 @@ void main() {
     expect(packing.length, 1);
   });
 
+  test('job reminder counts outstanding shopping and packing items', () async {
+    final shoppingItem = await _insertTaskItemForJob(
+      jobStatus: JobStatus.scheduled,
+      taskStatus: TaskStatus.inProgress,
+      itemType: TaskItemType.materialsBuy,
+      completed: false,
+    );
+    final task = (await DaoTask().getById(shoppingItem.taskId))!;
+    final job = (await DaoJob().getById(task.jobId))!;
+    await _insertTaskItemForExistingJob(
+      jobId: job.id,
+      itemType: TaskItemType.materialsStock,
+      completed: false,
+    );
+
+    final counts = await DaoTaskItem().getReminderCounts(job);
+
+    expect(counts.shopping, 1);
+    expect(counts.packing, 1);
+  });
+
   test('shopping excludes items for inactive task statuses', () async {
     final active = await _insertTaskItemForJob(
       jobStatus: JobStatus.inProgress,

--- a/test/util/notification_plan_test.dart
+++ b/test/util/notification_plan_test.dart
@@ -27,6 +27,8 @@ void main() {
       activityId: 7,
       jobId: 12,
       jobSummary: 'Repair leaking tap',
+      shoppingCount: 2,
+      packingCount: 3,
       startsAt: startsAt,
     );
 
@@ -37,6 +39,10 @@ void main() {
     );
     expect(notification.payload?['jobId'], '12');
     expect(notification.channel.id, 'HMB_NOTIF_JOB');
+    expect(
+      notification.body,
+      'Repair leaking tap starts soon\nShopping: 2 • Packing: 3',
+    );
   });
 
   test('Android declares scheduled notification receivers', () {


### PR DESCRIPTION
## Summary
- count outstanding shopping and packing items for each scheduled job
- include both counts in the upcoming-job notification body
- calculate counts when activities are saved and when reminders are rebuilt at startup

## Validation
- focused analysis of all changed notification, scheduling, DAO, and test files
- `flutter test test/util/notification_plan_test.dart test/dao/dao_task_item_test.dart`

Fixes #575