### PR TITLE
#562 Test photo sync resume after sign-in

### DIFF
--- a/lib/database/management/backup_providers/google_drive/background_backup/photo_sync_service.dart
+++ b/lib/database/management/backup_providers/google_drive/background_backup/photo_sync_service.dart
@@ -69,6 +69,19 @@ class PhotoSyncException implements Exception {
   String toString() => message;
 }
 
+StreamSubscription<bool> listenForPhotoSyncSignIn({
+  required Stream<bool> authStateChanges,
+  required bool Function() isWaitingForSignIn,
+  required bool Function() isRunning,
+  required void Function() clearWaitingForSignIn,
+  required Future<void> Function() start,
+}) => authStateChanges.listen((signedIn) {
+  if (signedIn && isWaitingForSignIn() && !isRunning()) {
+    clearWaitingForSignIn();
+    unawaited(start());
+  }
+});
+
 class PhotoSyncService {
   static final _instance = PhotoSyncService._();
   static const _maxAutoRetries = 3;
@@ -94,12 +107,13 @@ class PhotoSyncService {
 
   factory PhotoSyncService() => _instance;
   PhotoSyncService._() {
-    GoogleDriveAuth.authStateChanges.listen((signedIn) {
-      if (signedIn && _waitingForSignIn && !isRunning) {
-        _waitingForSignIn = false;
-        unawaited(start());
-      }
-    });
+    listenForPhotoSyncSignIn(
+      authStateChanges: GoogleDriveAuth.authStateChanges,
+      isWaitingForSignIn: () => _waitingForSignIn,
+      isRunning: () => isRunning,
+      clearWaitingForSignIn: () => _waitingForSignIn = false,
+      start: start,
+    );
   }
 
   Stream<ProgressUpdate> get progressStream => _controller.stream;

--- a/test/database/management/backup_providers/google_drive/background_backup/photo_sync_service_test.dart
+++ b/test/database/management/backup_providers/google_drive/background_backup/photo_sync_service_test.dart
@@ -2,10 +2,73 @@
 // ignore_for_file: lines_longer_than_80_chars
 library;
 
+import 'dart:async';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hmb/database/management/backup_providers/google_drive/background_backup/photo_sync_service.dart';
 
 void main() {
+  group('photo sync sign-in resume', () {
+    late StreamController<bool> authStateChanges;
+    late StreamSubscription<bool> subscription;
+    var waitingForSignIn = false;
+    var running = false;
+    var startCalls = 0;
+    var waitingWhenStarted = true;
+
+    setUp(() {
+      waitingForSignIn = false;
+      running = false;
+      startCalls = 0;
+      waitingWhenStarted = true;
+      authStateChanges = StreamController<bool>.broadcast(sync: true);
+      subscription = listenForPhotoSyncSignIn(
+        authStateChanges: authStateChanges.stream,
+        isWaitingForSignIn: () => waitingForSignIn,
+        isRunning: () => running,
+        clearWaitingForSignIn: () => waitingForSignIn = false,
+        start: () async {
+          startCalls++;
+          waitingWhenStarted = waitingForSignIn;
+        },
+      );
+    });
+
+    tearDown(() async {
+      await subscription.cancel();
+      await authStateChanges.close();
+    });
+
+    test('starts once when sign-in completes while sync is waiting', () {
+      waitingForSignIn = true;
+
+      authStateChanges
+        ..add(true)
+        ..add(true);
+
+      expect(startCalls, 1);
+      expect(waitingForSignIn, isFalse);
+      expect(waitingWhenStarted, isFalse);
+    });
+
+    test('ignores auth events when resume conditions are not met', () {
+      waitingForSignIn = true;
+      authStateChanges.add(false);
+      expect(startCalls, 0);
+      expect(waitingForSignIn, isTrue);
+
+      running = true;
+      authStateChanges.add(true);
+      expect(startCalls, 0);
+      expect(waitingForSignIn, isTrue);
+
+      running = false;
+      waitingForSignIn = false;
+      authStateChanges.add(true);
+      expect(startCalls, 0);
+    });
+  });
+
   group('isRecoverablePhotoSyncError', () {
     test('matches transient network and sleep interruption messages', () {
       expect(


### PR DESCRIPTION
## Summary
- extract the photo-sync sign-in resume listener for deterministic testing
- verify a waiting sync starts once after sign-in
- verify unrelated auth events and already-running syncs do not trigger another start

## Verification
- `flutter test --no-pub test/database/management/backup_providers/google_drive/background_backup/photo_sync_service_test.dart`
- `dart analyze lib/database/management/backup_providers/google_drive/background_backup/photo_sync_service.dart test/database/management/backup_providers/google_drive/background_backup/photo_sync_service_test.dart`

Closes #562