### PR TITLE
#569 Default new shopping item cost to zero

### DIFF
--- a/lib/ui/dialog/add_task_item.dart
+++ b/lib/ui/dialog/add_task_item.dart
@@ -36,7 +36,14 @@ Future<void> showAddItemDialog(BuildContext context, AddType addType) async {
   TaskItemType? selectedItemType;
   final descriptionController = TextEditingController();
   final purposeController = TextEditingController();
-  final priceController = MaterialPriceEditingController();
+  final priceController = MaterialPriceEditingController(
+    price: addType == AddType.shopping
+        ? MaterialPrice.items(
+            quantity: Fixed.one,
+            unitCost: Money.fromInt(0, isoCode: 'AUD'),
+          )
+        : null,
+  );
   final formKey = GlobalKey<FormState>();
 
   await showDialog<void>(

--- a/test/ui/dialog/add_task_item_test.dart
+++ b/test/ui/dialog/add_task_item_test.dart
@@ -42,4 +42,37 @@ void main() {
 
     expect(find.text('Please enter a Description'), findsOneWidget);
   });
+
+  testWidgets('shopping item cost defaults to zero', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => Scaffold(
+            body: ElevatedButton(
+              onPressed: () => showAddItemDialog(context, AddType.shopping),
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    final quantity = tester.widget<TextFormField>(
+      find.widgetWithText(TextFormField, 'Quantity'),
+    );
+    final cost = tester.widget<TextFormField>(
+      find.widgetWithText(TextFormField, 'Cost per item'),
+    );
+
+    expect(quantity.controller!.text, '1');
+    expect(cost.controller!.text, r'$0.00');
+
+    await tester.tap(find.text('Add'));
+    await tester.pump();
+
+    expect(find.text('Enter a valid cost'), findsNothing);
+  });
 }


### PR DESCRIPTION
## Summary
- default new shopping items to quantity 1 and a $0.00 estimated unit cost
- preserve the existing empty-price behavior for packing items
- add widget regression coverage for the shopping default and validation

## Verification
- `flutter test --no-pub test/ui/dialog/add_task_item_test.dart`
- `dart analyze lib/ui/dialog/add_task_item.dart test/ui/dialog/add_task_item_test.dart`

Closes #569