### PR TITLE
#58 Sync schedules and safety locations to Google Calendar

### DIFF
--- a/lib/dao/dao_job_activity.dart
+++ b/lib/dao/dao_job_activity.dart
@@ -153,6 +153,22 @@ SELECT ja.*
     return fromMap(data.first);
   }
 
+  Future<bool> hasActivityAt(int jobId, DateTime when) async {
+    final db = withoutTransaction();
+    final rows = await db.rawQuery(
+      '''
+SELECT 1
+  FROM $tableName
+ WHERE job_id = ?
+   AND start_date <= ?
+   AND end_date >= ?
+ LIMIT 1
+''',
+      [jobId, when.toIso8601String(), when.toIso8601String()],
+    );
+    return rows.isNotEmpty;
+  }
+
   Future<List<JobActivity>> getStartingAfter(DateTime date) async {
     final db = withoutTransaction();
     final finalisedStatuses = JobStatus.values

--- a/lib/database/management/backup_providers/google_drive/google_drive_auth.dart
+++ b/lib/database/management/backup_providers/google_drive/google_drive_auth.dart
@@ -16,6 +16,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:google_sign_in/google_sign_in.dart';
+import 'package:googleapis/calendar/v3.dart' as calendar;
 import 'package:googleapis/drive/v3.dart' as drive;
 import 'package:http/http.dart' as http;
 import 'package:settings_yaml/settings_yaml.dart';
@@ -43,7 +44,10 @@ class GoogleDriveAuth {
 
   static Stream<bool> get authStateChanges => _authStateController.stream;
 
-  final List<String> scopes = [drive.DriveApi.driveFileScope];
+  final List<String> scopes = [
+    drive.DriveApi.driveFileScope,
+    calendar.CalendarApi.calendarEventsScope,
+  ];
 
   var _signedIn = false;
 
@@ -281,6 +285,9 @@ class GoogleAuthClient extends http.BaseClient {
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) =>
       _client.send(request..headers.addAll(_headers));
+
+  @override
+  void close() => _client.close();
 }
 
 class GoogleAuthResult {

--- a/lib/integrations/google_calendar/google_calendar_sync.dart
+++ b/lib/integrations/google_calendar/google_calendar_sync.dart
@@ -1,0 +1,250 @@
+/*
+ Copyright © OnePub IP Pty Ltd. S. Brett Sutton. All Rights Reserved.
+
+ Note: This software is licensed under the GNU General Public License,
+         with the following exceptions:
+   • Permitted for internal use within your own business or organization only.
+   • Any external distribution, resale, or incorporation into products
+      for third parties is strictly prohibited.
+
+ See the full license on GitHub:
+ https://github.com/bsutton/hmb/blob/main/LICENSE
+*/
+
+import 'package:googleapis/calendar/v3.dart' as calendar;
+
+import '../../dao/dao_job_activity.dart';
+import '../../dao/dao_site.dart';
+import '../../database/management/backup_providers/google_drive/google_drive_auth.dart';
+import '../../entity/job.dart';
+import '../../entity/job_activity.dart';
+import '../../entity/site.dart';
+import '../../util/dart/app_settings.dart';
+
+enum ExternalCalendarSyncResult { synced, disabled, unavailable }
+
+class ExternalCalendarEventDraft {
+  const ExternalCalendarEventDraft({
+    required this.summary,
+    required this.description,
+    required this.location,
+    required this.start,
+    required this.end,
+    required this.sourceKey,
+    required this.sourceValue,
+  });
+
+  factory ExternalCalendarEventDraft.forJobActivity({
+    required JobActivity activity,
+    required Job job,
+    required Site? site,
+  }) => ExternalCalendarEventDraft(
+    summary: 'Job #${job.id}: ${job.summary}',
+    description: [
+      'Scheduled by HMB.',
+      if (activity.notes case final notes? when notes.trim().isNotEmpty)
+        notes.trim(),
+    ].join('\n'),
+    location: site?.address ?? '',
+    start: activity.start,
+    end: activity.end,
+    sourceKey: 'hmbJobActivityId',
+    sourceValue: activity.id.toString(),
+  );
+
+  factory ExternalCalendarEventDraft.forNavigation({
+    required Job job,
+    required Site site,
+    required DateTime when,
+  }) => ExternalCalendarEventDraft(
+    summary: 'Safety location — Job #${job.id}: ${job.summary}',
+    description:
+        'HMB recorded this location when directions were opened for an '
+        'unscheduled visit.',
+    location: site.address,
+    start: when,
+    end: when.add(const Duration(hours: 1)),
+    sourceKey: 'hmbNavigationKey',
+    sourceValue: '${job.id}:${_dateKey(when)}',
+  );
+
+  final String summary;
+  final String description;
+  final String location;
+  final DateTime start;
+  final DateTime end;
+  final String sourceKey;
+  final String sourceValue;
+}
+
+abstract class ExternalCalendarGateway {
+  Future<String?> findEventId({required String key, required String value});
+
+  Future<void> insert(ExternalCalendarEventDraft event);
+
+  Future<void> update(String eventId, ExternalCalendarEventDraft event);
+
+  Future<void> delete(String eventId);
+
+  void close();
+}
+
+class ExternalCalendarSynchronizer {
+  const ExternalCalendarSynchronizer(this.gateway);
+
+  final ExternalCalendarGateway gateway;
+
+  Future<void> upsert(ExternalCalendarEventDraft event) async {
+    final eventId = await gateway.findEventId(
+      key: event.sourceKey,
+      value: event.sourceValue,
+    );
+    if (eventId == null) {
+      await gateway.insert(event);
+    } else {
+      await gateway.update(eventId, event);
+    }
+  }
+
+  Future<void> deleteBySource({
+    required String key,
+    required String value,
+  }) async {
+    final eventId = await gateway.findEventId(key: key, value: value);
+    if (eventId != null) {
+      await gateway.delete(eventId);
+    }
+  }
+}
+
+class GoogleCalendarSyncService {
+  Future<ExternalCalendarSyncResult> upsertActivity({
+    required JobActivity activity,
+    required Job job,
+  }) async {
+    final site = await DaoSite().getByJob(job);
+    return _withSynchronizer(
+      (sync) => sync.upsert(
+        ExternalCalendarEventDraft.forJobActivity(
+          activity: activity,
+          job: job,
+          site: site,
+        ),
+      ),
+    );
+  }
+
+  Future<ExternalCalendarSyncResult> deleteActivity(JobActivity activity) =>
+      _withSynchronizer(
+        (sync) => sync.deleteBySource(
+          key: 'hmbJobActivityId',
+          value: activity.id.toString(),
+        ),
+      );
+
+  Future<ExternalCalendarSyncResult> recordNavigation({
+    required Job job,
+    required Site site,
+    DateTime? when,
+  }) async {
+    final navigationTime = when ?? DateTime.now();
+    if (await DaoJobActivity().hasActivityAt(job.id, navigationTime)) {
+      return ExternalCalendarSyncResult.synced;
+    }
+    return _withSynchronizer(
+      (sync) => sync.upsert(
+        ExternalCalendarEventDraft.forNavigation(
+          job: job,
+          site: site,
+          when: navigationTime,
+        ),
+      ),
+    );
+  }
+
+  Future<ExternalCalendarSyncResult> _withSynchronizer(
+    Future<void> Function(ExternalCalendarSynchronizer sync) operation,
+  ) async {
+    if (!await AppSettings.getGoogleCalendarSyncEnabled()) {
+      return ExternalCalendarSyncResult.disabled;
+    }
+    if (!GoogleDriveAuth.isAuthSupported()) {
+      return ExternalCalendarSyncResult.unavailable;
+    }
+    final auth = await GoogleDriveAuth.instance();
+    final headers = await auth.authHeadersOrNull();
+    if (headers == null) {
+      return ExternalCalendarSyncResult.unavailable;
+    }
+
+    final gateway = GoogleCalendarGateway.fromHeaders(headers);
+    try {
+      await operation(ExternalCalendarSynchronizer(gateway));
+      return ExternalCalendarSyncResult.synced;
+    } finally {
+      gateway.close();
+    }
+  }
+}
+
+class GoogleCalendarGateway implements ExternalCalendarGateway {
+  GoogleCalendarGateway._(this._client) : _api = calendar.CalendarApi(_client);
+
+  factory GoogleCalendarGateway.fromHeaders(Map<String, String> headers) =>
+      GoogleCalendarGateway._(GoogleAuthClient(headers));
+
+  static const _calendarId = 'primary';
+
+  final GoogleAuthClient _client;
+  final calendar.CalendarApi _api;
+
+  @override
+  Future<String?> findEventId({
+    required String key,
+    required String value,
+  }) async {
+    final events = await _api.events.list(
+      _calendarId,
+      privateExtendedProperty: ['$key=$value'],
+      maxResults: 1,
+      showDeleted: false,
+    );
+    final matches = events.items;
+    return matches == null || matches.isEmpty ? null : matches.first.id;
+  }
+
+  @override
+  Future<void> insert(ExternalCalendarEventDraft event) async {
+    await _api.events.insert(_toGoogleEvent(event), _calendarId);
+  }
+
+  @override
+  Future<void> update(String eventId, ExternalCalendarEventDraft event) async {
+    await _api.events.update(_toGoogleEvent(event), _calendarId, eventId);
+  }
+
+  @override
+  Future<void> delete(String eventId) async {
+    await _api.events.delete(_calendarId, eventId);
+  }
+
+  calendar.Event _toGoogleEvent(ExternalCalendarEventDraft event) =>
+      calendar.Event(
+        summary: event.summary,
+        description: event.description,
+        location: event.location,
+        start: calendar.EventDateTime(dateTime: event.start),
+        end: calendar.EventDateTime(dateTime: event.end),
+        extendedProperties: calendar.EventExtendedProperties(
+          private: {event.sourceKey: event.sourceValue},
+        ),
+      );
+
+  @override
+  void close() => _client.close();
+}
+
+String _dateKey(DateTime date) =>
+    '${date.year.toString().padLeft(4, '0')}'
+    '${date.month.toString().padLeft(2, '0')}'
+    '${date.day.toString().padLeft(2, '0')}';

--- a/lib/ui/crud/system/google_calendar_integration_screen.dart
+++ b/lib/ui/crud/system/google_calendar_integration_screen.dart
@@ -1,0 +1,103 @@
+/*
+ Copyright © OnePub IP Pty Ltd. S. Brett Sutton. All Rights Reserved.
+
+ Note: This software is licensed under the GNU General Public License,
+         with the following exceptions:
+   • Permitted for internal use within your own business or organization only.
+   • Any external distribution, resale, or incorporation into products
+      for third parties is strictly prohibited.
+
+ See the full license on GitHub:
+ https://github.com/bsutton/hmb/blob/main/LICENSE
+*/
+
+import 'package:deferred_state/deferred_state.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../util/dart/app_settings.dart';
+import '../../../util/flutter/app_title.dart';
+import '../../widgets/layout/layout.g.dart';
+import '../../widgets/widgets.g.dart';
+
+class GoogleCalendarIntegrationScreen extends StatefulWidget {
+  const GoogleCalendarIntegrationScreen({super.key});
+
+  @override
+  State<GoogleCalendarIntegrationScreen> createState() =>
+      _GoogleCalendarIntegrationScreenState();
+}
+
+class _GoogleCalendarIntegrationScreenState
+    extends DeferredState<GoogleCalendarIntegrationScreen> {
+  var _enabled = AppSettings.googleCalendarSyncEnabledDefault;
+
+  @override
+  Future<void> asyncInitState() async {
+    setAppTitle('Google Calendar Integration');
+    _enabled = await AppSettings.getGoogleCalendarSyncEnabled();
+  }
+
+  Future<bool> _save({required bool close}) async {
+    await AppSettings.setGoogleCalendarSyncEnabled(enabled: _enabled);
+    if (mounted) {
+      HMBToast.info('Google Calendar preference saved.');
+      if (close) {
+        context.go('/home/settings/integrations');
+      }
+    }
+    return true;
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+    body: DeferredBuilder(
+      this,
+      waitingBuilder: (context) => const SizedBox.shrink(),
+      builder: (context) => HMBColumn(
+        children: [
+          SaveAndClose(
+            onSave: _save,
+            showSaveOnly: false,
+            onCancel: () async => context.pop(),
+          ),
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                const Text(
+                  'HMB can copy schedule events to your primary Google '
+                  'Calendar. Schedule changes update the same calendar event '
+                  'and deleting a schedule removes it.',
+                ),
+                const HMBSpacer(height: true),
+                const Text(
+                  'Safety and privacy: when you open directions for a job '
+                  'that is not currently scheduled, HMB records that job '
+                  'location in Google Calendar for one hour. Anyone who can '
+                  'view that calendar may see where you travelled.',
+                ),
+                const HMBSpacer(height: true),
+                SwitchListTile(
+                  title: const Text('Google Calendar and safety sync'),
+                  subtitle: const Text(
+                    'Enabled by default. Turn this off to stop sending '
+                    'schedule and navigation locations to Google Calendar.',
+                  ),
+                  value: _enabled,
+                  onChanged: (value) => setState(() => _enabled = value),
+                ),
+                const HMBSpacer(height: true),
+                const Text(
+                  'Google Calendar uses the Google account connected from '
+                  'Backup. This is a one-way integration: changes made in '
+                  'Google Calendar are not copied back into HMB.',
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/lib/ui/nav/dashboards/integration/integration_dashboard.dart
+++ b/lib/ui/nav/dashboards/integration/integration_dashboard.dart
@@ -45,6 +45,13 @@ class IntegrationDashboardPage extends StatelessWidget {
         route: '/home/settings/integrations/google_maps',
       ),
       DashletCard<void>.route(
+        label: 'Google Calendar',
+        hint: 'Copy schedules and safety locations to Google Calendar',
+        icon: Icons.event_available,
+        value: () => Future.value(const DashletValue(null)),
+        route: '/home/settings/integrations/google_calendar',
+      ),
+      DashletCard<void>.route(
         label: 'Xero',
         hint: 'Configure integration with Xero to upload Invoices',
         icon: Icons.extension,

--- a/lib/ui/nav/route.dart
+++ b/lib/ui/nav/route.dart
@@ -27,6 +27,7 @@ import '../crud/milestone/list_milestone_screen.dart';
 import '../crud/receipt/list_receipt_screen.dart';
 import '../crud/supplier/list_supplier_screen.dart';
 import '../crud/system/chatgpt_integration_screen.dart';
+import '../crud/system/google_calendar_integration_screen.dart';
 import '../crud/system/google_maps_integration_screen.dart';
 import '../crud/system/ihserver_integration_screen.dart';
 import '../crud/system/plasterboard_layout_settings_screen.dart';
@@ -401,6 +402,12 @@ List<GoRoute> settingRoutes() => [
         path: 'google_maps',
         builder: (_, _) =>
             const HomeScaffold(initialScreen: GoogleMapsIntegrationScreen()),
+      ),
+      GoRoute(
+        path: 'google_calendar',
+        builder: (_, _) => const HomeScaffold(
+          initialScreen: GoogleCalendarIntegrationScreen(),
+        ),
       ),
       GoRoute(
         path: 'xero',

--- a/lib/ui/scheduling/day_schedule.dart
+++ b/lib/ui/scheduling/day_schedule.dart
@@ -402,6 +402,7 @@ class _DayScheduleState extends DeferredState<DaySchedule> {
               children: [
                 HMBMapIcon(
                   jobAndCustomer.site,
+                  job: jobAndCustomer.job,
                   onMapClicked: () async {
                     final job = jobAndCustomer.job;
                     await DaoJob().markActive(job.id);

--- a/lib/ui/scheduling/schedule_helper.dart
+++ b/lib/ui/scheduling/schedule_helper.dart
@@ -15,10 +15,12 @@ import 'package:calendar_view/calendar_view.dart';
 import 'package:flutter/material.dart';
 
 import '../../dao/dao.g.dart';
+import '../../integrations/google_calendar/google_calendar_sync.dart';
 import '../../util/dart/format.dart';
 import '../../util/dart/local_date.dart';
 import '../../util/flutter/notifications/local_notifs.dart';
 import '../dialog/send_notice_for_job_dialog.dart';
+import '../widgets/blocking_ui.dart';
 import '../widgets/hmb_toast.dart';
 import 'job_activity_dialog.dart';
 import 'job_activity_ex.dart';
@@ -66,6 +68,12 @@ mixin ScheduleHelper {
         );
         jobActivityAction.jobActivity!.jobActivity.id = newId;
         await _syncActivityReminder(jobActivityAction.jobActivity!);
+        await _syncExternalCalendar(
+          () => GoogleCalendarSyncService().upsertActivity(
+            activity: jobActivityAction.jobActivity!.jobActivity,
+            job: jobActivityAction.jobActivity!.job,
+          ),
+        );
         if (!context.mounted) {
           return;
         }
@@ -124,6 +132,12 @@ mixin ScheduleHelper {
     // 1) Update DB
     await dao.update(updated.jobActivity);
     await _syncActivityReminder(updated);
+    await _syncExternalCalendar(
+      () => GoogleCalendarSyncService().upsertActivity(
+        activity: updated.jobActivity,
+        job: updated.job,
+      ),
+    );
   }
 
   /// Delete an existing activity from the DB
@@ -131,6 +145,25 @@ mixin ScheduleHelper {
     final dao = DaoJobActivity();
     await dao.delete(activity.jobActivity.id);
     await LocalNotifs().cancelForJobActivity(activity.jobActivity.id);
+    await _syncExternalCalendar(
+      () => GoogleCalendarSyncService().deleteActivity(activity.jobActivity),
+    );
+  }
+
+  Future<void> _syncExternalCalendar(
+    Future<ExternalCalendarSyncResult> Function() operation,
+  ) async {
+    try {
+      final result = await BlockingUI().runAndWait(
+        operation,
+        label: 'Syncing Google Calendar',
+      );
+      if (result == ExternalCalendarSyncResult.unavailable) {
+        HMBToast.info('Schedule saved, but Google Calendar is not signed in.');
+      }
+    } catch (error) {
+      HMBToast.error('Schedule saved, but Google Calendar sync failed: $error');
+    }
   }
 
   Future<void> _syncActivityReminder(JobActivityEx activity) async {

--- a/lib/ui/scheduling/today/job_card.dart
+++ b/lib/ui/scheduling/today/job_card.dart
@@ -91,6 +91,7 @@ class JobCard extends StatelessWidget {
                 children: [
                   HMBMapIcon(
                     jobAndActivity.jobAndCustomer.site,
+                    job: jobAndActivity.jobAndCustomer.job,
                     onMapClicked: () async {
                       final job = jobAndActivity.jobAndCustomer.job;
                       await DaoJob().markActive(job.id);

--- a/lib/ui/widgets/icons/hmb_map_icon.dart
+++ b/lib/ui/widgets/icons/hmb_map_icon.dart
@@ -16,17 +16,21 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:strings/strings.dart';
 
+import '../../../entity/job.dart';
 import '../../../entity/site.dart';
+import '../../../integrations/google_calendar/google_calendar_sync.dart';
 import '../../../util/dart/address_format.dart';
 import '../../../util/flutter/clip_board.dart';
 import '../../../util/flutter/google_maps.dart';
+import '../hmb_toast.dart';
 
 class HMBMapIcon extends StatelessWidget {
   final Site? site;
+  final Job? job;
 
-  final void Function()? onMapClicked;
+  final Future<void> Function()? onMapClicked;
 
-  const HMBMapIcon(this.site, {super.key, this.onMapClicked});
+  const HMBMapIcon(this.site, {this.job, super.key, this.onMapClicked});
 
   @override
   Widget build(BuildContext context) {
@@ -49,8 +53,7 @@ class HMBMapIcon extends StatelessWidget {
           icon: const Icon(Icons.map),
           onPressed: () {
             if (site != null) {
-              unawaited(GoogleMaps.openMap(context, site!));
-              onMapClicked?.call();
+              unawaited(_openMap(context, site!));
             }
           },
           color: site != null && !site!.isEmpty() ? Colors.blue : Colors.grey,
@@ -62,7 +65,10 @@ class HMBMapIcon extends StatelessWidget {
           onPressed: () {
             if (Strings.isNotEmpty(address)) {
               unawaited(clipboardCopyTo(address));
-              onMapClicked?.call();
+              final callback = onMapClicked;
+              if (callback != null) {
+                unawaited(callback());
+              }
             }
           },
           color: Strings.isEmpty(address) ? Colors.grey : Colors.blue,
@@ -70,5 +76,32 @@ class HMBMapIcon extends StatelessWidget {
         ),
       ],
     );
+  }
+
+  Future<void> _openMap(BuildContext context, Site site) async {
+    await GoogleMaps.openMap(context, site);
+    final callback = onMapClicked;
+    if (callback != null) {
+      await callback();
+    }
+    final selectedJob = job;
+    if (selectedJob == null) {
+      return;
+    }
+    try {
+      final result = await GoogleCalendarSyncService().recordNavigation(
+        job: selectedJob,
+        site: site,
+      );
+      if (result == ExternalCalendarSyncResult.unavailable) {
+        HMBToast.info(
+          'Directions opened, but Google Calendar is not signed in.',
+        );
+      }
+    } catch (error) {
+      HMBToast.error(
+        'Directions opened, but the safety calendar event failed: $error',
+      );
+    }
   }
 }

--- a/lib/ui/widgets/text/hmb_site_text.dart
+++ b/lib/ui/widgets/text/hmb_site_text.dart
@@ -26,12 +26,14 @@ import '../layout/hmb_placeholder.dart';
 class HMBSiteText extends StatelessWidget {
   final String label;
   final Site? site;
+  final Job? job;
 
-  final void Function()? onMapClicked;
+  final Future<void> Function()? onMapClicked;
 
   const HMBSiteText({
     required this.label,
     required this.site,
+    this.job,
     this.onMapClicked,
     super.key,
   });
@@ -61,7 +63,7 @@ class HMBSiteText extends StatelessWidget {
           style: const TextStyle(color: HMBColors.textPrimary),
         ),
       ),
-      if (site != null) HMBMapIcon(site, onMapClicked: onMapClicked),
+      if (site != null) HMBMapIcon(site, job: job, onMapClicked: onMapClicked),
     ],
   );
 }
@@ -69,7 +71,7 @@ class HMBSiteText extends StatelessWidget {
 class HMBJobSiteText extends StatelessWidget {
   final String label;
   final Job? job;
-  final void Function()? onMapClicked;
+  final Future<void> Function()? onMapClicked;
 
   const HMBJobSiteText({
     required this.label,
@@ -83,7 +85,11 @@ class HMBJobSiteText extends StatelessWidget {
   Widget build(BuildContext context) => FutureBuilderEx(
     waitingBuilder: (_) => const HMBPlaceHolder(height: 32),
     future: DaoSite().getByJob(job),
-    builder: (context, site) =>
-        HMBSiteText(label: label, site: site, onMapClicked: onMapClicked),
+    builder: (context, site) => HMBSiteText(
+      label: label,
+      site: site,
+      job: job,
+      onMapClicked: onMapClicked,
+    ),
   );
 }

--- a/lib/util/dart/app_settings.dart
+++ b/lib/util/dart/app_settings.dart
@@ -32,6 +32,8 @@ enum TaxDisplayMode {
 }
 
 class AppSettings {
+  static const googleCalendarSyncEnabledDefault = true;
+  static const _googleCalendarSyncEnabledKey = 'googleCalendarSyncEnabled';
   static const photoCacheMaxMbDefault = 100;
   static const _photoCacheMaxMbKey = 'photoCacheMaxMb';
   static const defaultProfitMarginTextDefault = '20';
@@ -51,6 +53,26 @@ class AppSettings {
   static const _plasterFragmentationWeightKey = 'plasterFragmentationWeight';
   static const _plasterVerticalWallPenaltyWeightKey =
       'plasterVerticalWallPenaltyWeight';
+
+  static Future<bool> getGoogleCalendarSyncEnabled() async {
+    final settings = SettingsYaml.load(pathToSettings: await getSettingsPath());
+    final value = settings[_googleCalendarSyncEnabledKey];
+    if (value is bool) {
+      return value;
+    }
+    if (value is String) {
+      return bool.tryParse(value) ?? googleCalendarSyncEnabledDefault;
+    }
+    return googleCalendarSyncEnabledDefault;
+  }
+
+  static Future<void> setGoogleCalendarSyncEnabled({
+    required bool enabled,
+  }) async {
+    final settings = SettingsYaml.load(pathToSettings: await getSettingsPath());
+    settings[_googleCalendarSyncEnabledKey] = enabled;
+    await settings.save();
+  }
 
   static Future<int> getPhotoCacheMaxMb() async {
     final settings = SettingsYaml.load(pathToSettings: await getSettingsPath());

--- a/test/dao/dao_job_activity_test.dart
+++ b/test/dao/dao_job_activity_test.dart
@@ -77,4 +77,35 @@ void main() {
 
     expect(activities.map((activity) => activity.id), [activeActivity.id]);
   });
+
+  test('detects whether a job is scheduled at a given time', () async {
+    final now = DateTime(2026, 8, 11, 10);
+    final job = await createJob(
+      now,
+      BillingType.timeAndMaterial,
+      hourlyRate: Money.fromInt(5000, isoCode: 'AUD'),
+    );
+    await DaoJobActivity().insert(
+      JobActivity.forInsert(
+        jobId: job.id,
+        start: now,
+        end: now.add(const Duration(hours: 2)),
+      ),
+    );
+
+    expect(
+      await DaoJobActivity().hasActivityAt(
+        job.id,
+        now.add(const Duration(hours: 1)),
+      ),
+      isTrue,
+    );
+    expect(
+      await DaoJobActivity().hasActivityAt(
+        job.id,
+        now.subtract(const Duration(minutes: 1)),
+      ),
+      isFalse,
+    );
+  });
 }

--- a/test/integrations/google_calendar/google_calendar_sync_test.dart
+++ b/test/integrations/google_calendar/google_calendar_sync_test.dart
@@ -1,0 +1,130 @@
+import 'package:hmb/entity/entity.g.dart';
+import 'package:hmb/integrations/google_calendar/google_calendar_sync.dart';
+import 'package:money2/money2.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('inserts a schedule event when no matching event exists', () async {
+    final gateway = _FakeCalendarGateway();
+    final draft = _activityDraft();
+
+    await ExternalCalendarSynchronizer(gateway).upsert(draft);
+
+    expect(gateway.inserted, [draft]);
+    expect(gateway.updated, isEmpty);
+    expect(gateway.lastLookup, ('hmbJobActivityId', '41'));
+  });
+
+  test(
+    'updates the matching schedule event instead of duplicating it',
+    () async {
+      final gateway = _FakeCalendarGateway(existingEventId: 'google-event-7');
+      final draft = _activityDraft();
+
+      await ExternalCalendarSynchronizer(gateway).upsert(draft);
+
+      expect(gateway.inserted, isEmpty);
+      expect(gateway.updated.single, ('google-event-7', draft));
+    },
+  );
+
+  test('deletes the matching schedule event', () async {
+    final gateway = _FakeCalendarGateway(existingEventId: 'google-event-8');
+
+    await ExternalCalendarSynchronizer(
+      gateway,
+    ).deleteBySource(key: 'hmbJobActivityId', value: '41');
+
+    expect(gateway.deleted, ['google-event-8']);
+  });
+
+  test('navigation event identifies one job visit per local day', () {
+    final job = _job();
+    final site = _site();
+    final when = DateTime(2026, 8, 11, 9, 30);
+
+    final draft = ExternalCalendarEventDraft.forNavigation(
+      job: job,
+      site: site,
+      when: when,
+    );
+
+    expect(draft.sourceKey, 'hmbNavigationKey');
+    expect(draft.sourceValue, '17:20260811');
+    expect(draft.location, '1 Test Street, Testville, VIC, 3000');
+    expect(draft.end, when.add(const Duration(hours: 1)));
+  });
+}
+
+ExternalCalendarEventDraft _activityDraft() {
+  final activity = JobActivity.forInsert(
+    jobId: 17,
+    start: DateTime(2026, 8, 11, 9),
+    end: DateTime(2026, 8, 11, 11),
+    notes: 'Bring the ladder',
+  )..id = 41;
+  return ExternalCalendarEventDraft.forJobActivity(
+    activity: activity,
+    job: _job(),
+    site: _site(),
+  );
+}
+
+Job _job() => Job.forInsert(
+  customerId: 2,
+  summary: 'Repair gutter',
+  description: '',
+  siteId: 3,
+  contactId: 4,
+  status: JobStatus.scheduled,
+  hourlyRate: Money.fromInt(10000, isoCode: 'AUD'),
+  bookingFee: Money.fromInt(0, isoCode: 'AUD'),
+  billingContactId: 4,
+)..id = 17;
+
+Site _site() => Site.forInsert(
+  name: 'Test site',
+  addressLine1: '1 Test Street',
+  addressLine2: '',
+  suburb: 'Testville',
+  state: 'VIC',
+  postcode: '3000',
+  accessDetails: null,
+)..id = 3;
+
+class _FakeCalendarGateway implements ExternalCalendarGateway {
+  _FakeCalendarGateway({this.existingEventId});
+
+  final String? existingEventId;
+  (String, String)? lastLookup;
+  final inserted = <ExternalCalendarEventDraft>[];
+  final updated = <(String, ExternalCalendarEventDraft)>[];
+  final deleted = <String>[];
+
+  @override
+  Future<String?> findEventId({
+    required String key,
+    required String value,
+  }) async {
+    lastLookup = (key, value);
+    return existingEventId;
+  }
+
+  @override
+  Future<void> insert(ExternalCalendarEventDraft event) async {
+    inserted.add(event);
+  }
+
+  @override
+  Future<void> update(String eventId, ExternalCalendarEventDraft event) async {
+    updated.add((eventId, event));
+  }
+
+  @override
+  Future<void> delete(String eventId) async {
+    deleted.add(eventId);
+  }
+
+  @override
+  void close() {}
+}

--- a/test/util/google_calendar_settings_test.dart
+++ b/test/util/google_calendar_settings_test.dart
@@ -1,0 +1,20 @@
+import 'package:hmb/util/dart/app_settings.dart';
+import 'package:test/test.dart';
+
+import 'settings_test_helper.dart';
+
+void main() {
+  setUpAll(prepareSettingsTest);
+
+  setUp(() async {
+    await resetSettingsForTest();
+  });
+
+  test('Google Calendar sync defaults on and can be disabled', () async {
+    expect(await AppSettings.getGoogleCalendarSyncEnabled(), isTrue);
+
+    await AppSettings.setGoogleCalendarSyncEnabled(enabled: false);
+
+    expect(await AppSettings.getGoogleCalendarSyncEnabled(), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- add one-way Google Calendar synchronization for schedule creation, edits, and deletion
- avoid duplicate events by storing stable HMB identifiers in private Google Calendar event properties
- record a one-hour safety-location event when directions are opened for an unscheduled job visit
- add a default-on privacy setting under Settings → Integrations → Google Calendar
- extend Google sign-in authorization with the Calendar events scope while retaining Drive access
- keep the external-calendar gateway abstract so another provider can be added later

## Verification
- `flutter test --no-pub test/integrations/google_calendar/google_calendar_sync_test.dart test/util/google_calendar_settings_test.dart test/dao/dao_job_activity_test.dart test/database/management/backup_providers/google_drive/background_backup/photo_sync_service_test.dart` (12 passed)
- targeted `dart analyze` over all changed files (no issues)
- repository-wide `flutter analyze` reaches only existing `packages/room_editor` missing dependency errors for `flutter_lints` and `flutter_svg`

## Deployment note
The Google Cloud project used by the existing sign-in client must have Google Calendar API enabled and the Calendar events scope allowed on its OAuth consent configuration.

Closes #58