### PR TITLE
#592 Prevent repeated Gmail sign-in

### DIFF
--- a/lib/integrations/gmail/gmail_import_service.dart
+++ b/lib/integrations/gmail/gmail_import_service.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:googleapis/gmail/v1.dart' as gmail;
 
 import '../../database/management/backup_providers/google_drive/google_drive.g.dart';
@@ -80,7 +82,9 @@ class GmailImportService {
   static const _maximumMessagesScannedPerSearch = 300;
   final GoogleMailAuth _auth;
   GoogleAuthClient? _activeClient;
-  var _cancelRequested = false;
+  GoogleMailAccessToken? _cachedAccess;
+  Future<GoogleMailAccessToken>? _pendingAccess;
+  _GmailSearchOperation? _activeSearch;
 
   GmailImportService({GoogleMailAuth? auth}) : _auth = auth ?? GoogleMailAuth();
 
@@ -90,10 +94,44 @@ class GmailImportService {
     String? pageToken,
     int maxResults = 30,
   }) async {
-    _cancelRequested = false;
+    final previousSearch = _activeSearch;
+    previousSearch?.cancel();
+    _activeClient?.close();
+
+    final operation = _GmailSearchOperation();
+    _activeSearch = operation;
+    final search = _search(
+      operation,
+      query: query,
+      textFilter: textFilter,
+      pageToken: pageToken,
+      maxResults: maxResults,
+    );
+    try {
+      return await Future.any([
+        search,
+        operation.whenCancelled.then<GmailSearchResult>(
+          (_) => throw const GmailImportCancelled(),
+        ),
+      ]);
+    } finally {
+      if (identical(_activeSearch, operation)) {
+        _activeSearch = null;
+      }
+    }
+  }
+
+  Future<GmailSearchResult> _search(
+    _GmailSearchOperation operation, {
+    required String query,
+    required String? textFilter,
+    required String? pageToken,
+    required int maxResults,
+  }) async {
     GoogleAuthClient? client;
     try {
-      final access = await _auth.getReadAccessToken();
+      final access = await readAccessToken();
+      operation.throwIfCancelled();
       client = GoogleAuthClient({
         'Authorization': 'Bearer ${access.accessToken}',
         'X-Goog-AuthUser': '0',
@@ -101,6 +139,7 @@ class GmailImportService {
       _activeClient = client;
       final api = gmail.GmailApi(client);
       final profile = await api.users.getProfile('me');
+      operation.throwIfCancelled();
       final messages = <GmailMessageSummary>[];
       var activePageToken = pageToken;
       String? nextPageToken;
@@ -113,8 +152,9 @@ class GmailImportService {
           pageToken: activePageToken,
           maxResults: maxResults,
         );
+        operation.throwIfCancelled();
         final references = response.messages ?? const <gmail.Message>[];
-        final summaries = await _loadSummaries(api, references);
+        final summaries = await _loadSummaries(api, references, operation);
         messages.addAll(_filterSummaries(summaries, textFilter));
         scanned += references.length;
         nextPageToken = response.nextPageToken;
@@ -129,12 +169,12 @@ class GmailImportService {
         nextPageToken: nextPageToken,
       );
     } on gmail.DetailedApiRequestError catch (error) {
-      if (_cancelRequested) {
+      if (operation.cancelled) {
         throw const GmailImportCancelled();
       }
       throw _friendlyApiError(error);
     } catch (error) {
-      if (_cancelRequested || error is GoogleMailAuthorizationCancelled) {
+      if (operation.cancelled || error is GoogleMailAuthorizationCancelled) {
         throw const GmailImportCancelled();
       }
       rethrow;
@@ -170,16 +210,36 @@ class GmailImportService {
   }
 
   Future<void> cancelPendingOperation() async {
-    _cancelRequested = true;
+    _activeSearch?.cancel();
     await _auth.cancelPendingAuthorization();
     _activeClient?.close();
+  }
+
+  @visibleForTesting
+  Future<GoogleMailAccessToken> readAccessToken() async {
+    final cached = _cachedAccess;
+    if (cached != null) {
+      return cached;
+    }
+
+    final pending = _pendingAccess ?? _auth.getReadAccessToken();
+    _pendingAccess = pending;
+    try {
+      final access = await pending;
+      _cachedAccess = access;
+      return access;
+    } finally {
+      if (identical(_pendingAccess, pending)) {
+        _pendingAccess = null;
+      }
+    }
   }
 
   Future<JobCreationEmailSource> loadMessage({
     required String accountEmail,
     required String messageId,
   }) async {
-    final access = await _auth.getReadAccessToken();
+    final access = await readAccessToken();
     final client = GoogleAuthClient({
       'Authorization': 'Bearer ${access.accessToken}',
       'X-Goog-AuthUser': '0',
@@ -216,7 +276,7 @@ class GmailImportService {
       return const [];
     }
 
-    final access = await _auth.getReadAccessToken();
+    final access = await readAccessToken();
     final client = GoogleAuthClient({
       'Authorization': 'Bearer ${access.accessToken}',
       'X-Goog-AuthUser': '0',
@@ -270,6 +330,7 @@ class GmailImportService {
   Future<List<GmailMessageSummary>> _loadSummaries(
     gmail.GmailApi api,
     List<gmail.Message> references,
+    _GmailSearchOperation operation,
   ) async {
     final summaries = <GmailMessageSummary>[];
     for (
@@ -277,9 +338,7 @@ class GmailImportService {
       offset < references.length;
       offset += _summaryBatchSize
     ) {
-      if (_cancelRequested) {
-        throw const GmailImportCancelled();
-      }
+      operation.throwIfCancelled();
       final proposedEnd = offset + _summaryBatchSize;
       final end = proposedEnd < references.length
           ? proposedEnd
@@ -301,6 +360,25 @@ class GmailImportService {
   ) => summaries
       .where((message) => gmailMessageMatchesText(message, textFilter))
       .toList();
+}
+
+class _GmailSearchOperation {
+  final _cancelled = Completer<void>();
+
+  bool get cancelled => _cancelled.isCompleted;
+  Future<void> get whenCancelled => _cancelled.future;
+
+  void cancel() {
+    if (!cancelled) {
+      _cancelled.complete();
+    }
+  }
+
+  void throwIfCancelled() {
+    if (cancelled) {
+      throw const GmailImportCancelled();
+    }
+  }
 }
 
 class GmailImportCancelled implements Exception {

--- a/lib/ui/crud/job/gmail_job_import_screen.dart
+++ b/lib/ui/crud/job/gmail_job_import_screen.dart
@@ -57,6 +57,12 @@ class _GmailJobImportScreenState extends DeferredState<GmailJobImportScreen> {
   }
 
   @override
+  void dispose() {
+    unawaited(_service.cancelPendingOperation());
+    super.dispose();
+  }
+
+  @override
   Future<void> asyncInitState() => _startSearch();
 
   Future<void> _search({

--- a/lib/ui/widgets/blocking_ui.dart
+++ b/lib/ui/widgets/blocking_ui.dart
@@ -25,6 +25,7 @@ import '../../util/dart/log.dart';
 import '../../util/dart/stack_list.dart';
 import '../../util/flutter/hmb_theme.dart';
 import 'color_ex.dart';
+import 'hmb_button.dart';
 import 'layout/layout.g.dart';
 import 'text/hmb_text_themes.dart';
 import 'tick_builder.dart';
@@ -207,9 +208,10 @@ class _BlockingOverlayWidgetState extends State<_BlockingOverlayWidget> {
                           Semantics(
                             button: true,
                             label: 'Cancel this operation',
-                            child: TextButton(
+                            child: HMBButton.small(
+                              label: 'Cancel',
+                              hint: 'Cancel this operation',
                               onPressed: cancelRun,
-                              child: const Text('Cancel'),
                             ),
                           ),
                       ],

--- a/test/integrations/gmail/gmail_import_service_test.dart
+++ b/test/integrations/gmail/gmail_import_service_test.dart
@@ -1,8 +1,10 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:googleapis/gmail/v1.dart' as gmail;
 import 'package:hmb/integrations/gmail/gmail_import_service.dart';
 import 'package:hmb/ui/crud/job/job_creation_email_source.dart';
+import 'package:hmb/ui/dialog/google_mail_auth.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -123,6 +125,55 @@ void main() {
 
     expect(utf8.decode(bytes), 'hello');
   });
+
+  test('reuses Gmail authorization for subsequent searches', () async {
+    final auth = _FakeGoogleMailAuth();
+    final service = GmailImportService(auth: auth);
+
+    await service.readAccessToken();
+    await service.readAccessToken();
+
+    expect(auth.authorizationRequests, 1);
+  });
+
+  test('cancelling releases a search waiting for authentication', () async {
+    final auth = _HangingGoogleMailAuth();
+    final service = GmailImportService(auth: auth);
+    final search = service.search();
+    final cancelled = expectLater(search, throwsA(isA<GmailImportCancelled>()));
+    await Future<void>.delayed(Duration.zero);
+
+    await service.cancelPendingOperation();
+
+    await cancelled;
+    expect(auth.cancelled, isTrue);
+  });
 }
 
 String _encode(String value) => base64UrlEncode(utf8.encode(value));
+
+class _FakeGoogleMailAuth extends GoogleMailAuth {
+  var authorizationRequests = 0;
+
+  @override
+  Future<GoogleMailAccessToken> getReadAccessToken() async {
+    authorizationRequests++;
+    return const GoogleMailAccessToken(
+      email: 'owner@example.com',
+      accessToken: 'access-token',
+    );
+  }
+}
+
+class _HangingGoogleMailAuth extends GoogleMailAuth {
+  final _authorization = Completer<GoogleMailAccessToken>();
+  var cancelled = false;
+
+  @override
+  Future<GoogleMailAccessToken> getReadAccessToken() => _authorization.future;
+
+  @override
+  Future<void> cancelPendingAuthorization() async {
+    cancelled = true;
+  }
+}

--- a/test/ui/crud/job/gmail_job_import_ui_test.dart
+++ b/test/ui/crud/job/gmail_job_import_ui_test.dart
@@ -12,6 +12,7 @@ import 'package:hmb/ui/crud/job/job_creation_email_source.dart';
 import 'package:hmb/ui/crud/job/job_creator.dart';
 import 'package:hmb/ui/crud/job/list_job_screen.dart';
 import 'package:hmb/ui/widgets/blocking_ui.dart';
+import 'package:hmb/ui/widgets/hmb_button.dart';
 import 'package:hmb/ui/widgets/icons/hmb_add_button.dart';
 import 'package:june/june.dart';
 
@@ -106,11 +107,18 @@ void main() {
       ),
     );
     await tester.pump();
+    await tester.pump();
 
     final overlay = June.getState(BlockingOverlayState.new);
     expect(overlay.blocked, isTrue);
     expect(overlay.topAction.canCancel, isTrue);
-    await overlay.topAction.cancel();
+    await tester.runAsync(
+      () => Future<void>.delayed(const Duration(milliseconds: 1100)),
+    );
+    await tester.pump(const Duration(milliseconds: 1100));
+    final cancelButton = find.widgetWithText(HMBButton, 'Cancel');
+    expect(cancelButton, findsOneWidget);
+    await tester.tap(cancelButton);
     await _pumpAsyncWork(tester);
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
## What changed

- cache the Gmail read authorization for subsequent searches and message loads
- make cancellation immediately release a search stuck in authentication or an HTTP request
- cancel pending Gmail work when the import screen is disposed
- use the shared compact HMB button for the blocking overlay cancel action
- add regression coverage for authorization reuse, cancellation during authentication, and the visible cancel control

## Why

Issue #592 reports that applying a Gmail filter prompted for the account a second time, then left the blocking overlay stuck. The import service requested authentication for every operation, and cancellation could not complete the search future while authentication was still pending.

## Validation

- `flutter test --no-pub test/integrations/gmail/gmail_import_service_test.dart test/ui/widgets/blocking_ui_test.dart`
- `flutter test --no-pub test/ui/crud/job/gmail_job_import_ui_test.dart`
- focused `flutter analyze --no-pub` on all five changed source/test files
- `git diff --check`

Fixes #592 after merge.